### PR TITLE
Fix Cursor Python command execution with simplified pip-based installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ octave-workspace
 matlab_output/
 test_output/
 *.code-workspace
+mcp-pip.json
 
 # Jupyter
 .ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Model Context Protocol (MCP) server that provides tools for developing and run
 
 - Python 3.8+
 - MATLAB with Python Engine installed
+- uv package manager (recommended)
 
 ## Features
 
@@ -21,6 +22,50 @@ A Model Context Protocol (MCP) server that provides tools for developing and run
    - Maintain workspace context between sections
 
 ## Installation
+
+### Using pip (Recommended)
+
+1. Clone this repository:
+```bash
+git clone [repository-url]
+cd matlab-mcp-tools
+```
+
+2. Set the MATLAB path environment variable if your MATLAB is not in the default location:
+```bash
+# For macOS (default is /Applications/MATLAB_R2024b.app)
+export MATLAB_PATH=/path/to/your/matlab/installation
+
+# For Windows (default might be C:\Program Files\MATLAB\R2024b)
+# set MATLAB_PATH=C:\path\to\your\matlab\installation
+```
+
+3. Run the setup script to install the package with pip:
+```bash
+./setup-pip-matlab-mcp.sh
+```
+
+4. Configure Cline/Cursor by copying the provided MCP configuration:
+```bash
+# For macOS/Linux
+cp mcp-pip.json ~/.cursor/mcp.json
+
+# For Windows
+# copy mcp-pip.json %USERPROFILE%\.cursor\mcp.json
+```
+
+5. Test the installation:
+```bash
+./test-pip-matlab-mcp.sh
+```
+
+After setup, you can run the MATLAB MCP server using:
+```bash
+matlab-mcp-server
+```
+
+
+### Using Conda (Alternative)
 
 1. Clone this repository:
 
@@ -40,18 +85,61 @@ conda activate matlab-mcp
 pip install -e .
 ```
 
-4. Install MATLAB Engine for Python:
+4. Set the MATLAB path environment variable:
+```bash
+# For macOS (default is /Applications/MATLAB_R2024b.app)
+export MATLAB_PATH=/path/to/your/matlab/installation
+
+# For Windows (default might be C:\Program Files\MATLAB\R2024b)
+# set MATLAB_PATH=C:\path\to\your\matlab\installation
+```
+
+5. Install MATLAB Engine for Python:
 ```bash
 # Navigate to MATLAB engine directory
-cd /Applications/MATLAB_R2024b.app/extern/engines/python
+cd $MATLAB_PATH/extern/engines/python
 
 # Install MATLAB engine
 python setup.py install
 ```
 
-5. Add MATLAB to system PATH:
+6. Add MATLAB to system PATH:
 ```bash
-export PATH="/Applications/MATLAB_R2024b.app/:$PATH"
+# For macOS/Linux
+export PATH="$MATLAB_PATH/bin:$PATH"
+
+# For Windows
+# set PATH=%MATLAB_PATH%\bin;%PATH%
+```
+
+7. Create a configuration file for Cline/Cursor:
+```bash
+cat > mcp-conda.json << EOF
+{
+  "mcpServers": {
+    "matlab": {
+      "command": "matlab-mcp-server",
+      "args": [],
+      "env": {
+        "MATLAB_PATH": "\${MATLAB_PATH}",
+        "PATH": "\${MATLAB_PATH}/bin:\${PATH}"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "list_tools",
+        "get_script_sections"
+      ]
+    }
+  }
+}
+EOF
+
+# Copy to Cline/Cursor configuration
+# For macOS/Linux
+cp mcp-conda.json ~/.cursor/mcp.json
+
+# For Windows
+# copy mcp-conda.json %USERPROFILE%\.cursor\mcp.json
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ cd matlab-mcp-tools
 # For macOS (default is /Applications/MATLAB_R2024b.app)
 export MATLAB_PATH=/path/to/your/matlab/installation
 
-# For Windows (default might be C:\Program Files\MATLAB\R2024b)
-# set MATLAB_PATH=C:\path\to\your\matlab\installation
+# For Windows use Git Bash terminal (default might be C:\Program Files\MATLAB\R2024b)
+# Also use forward slashes and double quotes for paths with spaces
+# export MATLAB_PATH="C:/path/to/your/matlab/installation"
 ```
 
 3. Run the setup script to install the package with pip:

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ A Model Context Protocol (MCP) server that provides tools for developing and run
 ### Using pip (Recommended)
 
 1. Clone this repository:
+
 ```bash
 git clone [repository-url]
 cd matlab-mcp-tools
 ```
 
 2. Set the MATLAB path environment variable if your MATLAB is not in the default location:
+
 ```bash
 # For macOS (default is /Applications/MATLAB_R2024b.app)
 export MATLAB_PATH=/path/to/your/matlab/installation
@@ -42,11 +44,13 @@ export MATLAB_PATH=/path/to/your/matlab/installation
 ```
 
 3. Run the setup script to install the package with pip:
+
 ```bash
 ./setup-pip-matlab-mcp.sh
 ```
 
 4. Configure Cline/Cursor by copying the provided MCP configuration:
+
 ```bash
 # For macOS/Linux
 cp mcp-pip.json ~/.cursor/mcp.json
@@ -56,96 +60,27 @@ cp mcp-pip.json ~/.cursor/mcp.json
 ```
 
 5. Test the installation:
+
 ```bash
 ./test-pip-matlab-mcp.sh
 ```
 
 After setup, you can run the MATLAB MCP server using:
+
 ```bash
 matlab-mcp-server
 ```
 
-
-### Using Conda (Alternative)
-
-1. Clone this repository:
-
-```bash
-git clone [repository-url]
-cd matlab-mcp-tools
-```
-
-2. Create and activate a Conda environment:
-```bash
-conda create -n matlab-mcp python=3.8
-conda activate matlab-mcp
-```
-
-3. Install the package and its dependencies:
-```bash
-pip install -e .
-```
-
-4. Set the MATLAB path environment variable:
-```bash
-# For macOS (default is /Applications/MATLAB_R2024b.app)
-export MATLAB_PATH=/path/to/your/matlab/installation
-
-# For Windows (default might be C:\Program Files\MATLAB\R2024b)
-# set MATLAB_PATH=C:\path\to\your\matlab\installation
-```
-
-5. Install MATLAB Engine for Python:
-```bash
-# Navigate to MATLAB engine directory
-cd $MATLAB_PATH/extern/engines/python
-
-# Install MATLAB engine
-python setup.py install
-```
-
-6. Add MATLAB to system PATH:
-```bash
-# For macOS/Linux
-export PATH="$MATLAB_PATH/bin:$PATH"
-
-# For Windows
-# set PATH=%MATLAB_PATH%\bin;%PATH%
-```
-
-7. Create a configuration file for Cline/Cursor:
-```bash
-cat > mcp-conda.json << EOF
-{
-  "mcpServers": {
-    "matlab": {
-      "command": "matlab-mcp-server",
-      "args": [],
-      "env": {
-        "MATLAB_PATH": "\${MATLAB_PATH}",
-        "PATH": "\${MATLAB_PATH}/bin:\${PATH}"
-      },
-      "disabled": false,
-      "autoApprove": [
-        "list_tools",
-        "get_script_sections"
-      ]
-    }
-  }
-}
-EOF
-
-# Copy to Cline/Cursor configuration
-# For macOS/Linux
-cp mcp-conda.json ~/.cursor/mcp.json
-
-# For Windows
-# copy mcp-conda.json %USERPROFILE%\.cursor\mcp.json
-```
+Troubleshooting: See [Installation Troubleshooting](#installation-troubleshooting) for common issues and solutions. Don't hesitate to open an issue on the repository if you encounter an issue that is not listed, and a PR if you have a solution.
 
 ## Usage
 
 1. Start the MCP server:
+```bash
+matlab-mcp-server
+```
+
+This is equivalent to running:
 ```bash
 python -m matlab_mcp.server
 ```
@@ -163,16 +98,22 @@ Available tools:
 Use the tools with Cline or other MCP-compatible clients.
 ```
 
-2. Alternatively, configure Cline to use the MATLAB MCP server by adding to your Cline configuration:
+2. Use the provided MCP configuration (see [Installation](#installation)) file to configure Cline/Cursor:
 ```json
 {
   "mcpServers": {
     "matlab": {
-      "command": "python",
-      "args": ["-m", "matlab_mcp.server"],
+      "command": "matlab-mcp-server",
+      "args": [],
       "env": {
-        "PYTHONPATH": "/path/to/matlab/engine/installation"
-      }
+        "MATLAB_PATH": "${MATLAB_PATH}",
+        "PATH": "${MATLAB_PATH}/bin:${PATH}"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "list_tools",
+        "get_script_sections"
+      ]
     }
   }
 }
@@ -308,6 +249,27 @@ The tool creates `matlab_output` and `test_output` directories to store:
 - Script execution errors are captured and returned with detailed error messages
 - Workspace state is preserved even after errors
 
+## Installation Troubleshooting
+
+1. Note that the `setup-pip-matlab-mcp.sh` script is designed to be run from the root of the repository.
+2. The script is dependent on `pip` and `python` being installed. So make sure you have those installed.
+3. If the scripts run, but you get an ENONET error, make sure that the Python executable used to run the install script is the same Python executable that Cline/Cursor is using. Otherwise, you can specify the Python executable in the MCP configuration file within the `command` and `args` keys. For example:
+
+```json
+{
+      "command": "bash",
+      "args": ["-c", "source $(conda info --base)/etc/profile.d/conda.sh && conda activate target_environment && matlab-mcp-server"],
+}
+```
+
+In this case, the `target_environment` is the name of the Conda environment that was used to install the `matlab-mcp-tools` package.
+
+4. Running the `setup-pip-matlab-mcp.sh` in Windows requires using Git Bash terminal with ADMIN privileges. This is because the script needs to install the `matlab-mcp-tools` package using `pip` and this requires admin privileges.
+
+5. Matlab Python Engine requires specific versions of Python and MATLAB. See the [Matlab Python Engine](https://www.mathworks.com/help/matlab/matlab-engine-for-python.html) and the [Python Versions Compatibility](https://www.mathworks.com/support/requirements/python-compatibility.html) documentations for more information.
+
+6. Matlab requires a license to be running to use the Python Engine.
+
 ## Contributing
 
 1. Fork the repository
@@ -316,4 +278,4 @@ The tool creates `matlab_output` and `test_output` directories to store:
 
 ## License
 
-BSD-3-Clause
+This project is licensed under the BSD-3-Clause License. See the [LICENSE](LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 
 [project.scripts]
-matlab-mcp = "matlab_mcp.server:main"
+matlab-mcp-server = "matlab_mcp.server:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/setup-pip-matlab-mcp.sh
+++ b/setup-pip-matlab-mcp.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# Define variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MATLAB_PATH=${MATLAB_PATH}
+
+# Print header
+echo "Setting up matlab-mcp-server with pip"
+echo "MATLAB path: $MATLAB_PATH"
+echo "Project dir: $SCRIPT_DIR"
+
+# Check if MATLAB exists
+if [ ! -d "$MATLAB_PATH" ]; then
+    echo "Error: MATLAB not found at $MATLAB_PATH"
+    echo "Please set the MATLAB_PATH environment variable to the correct location"
+    exit 1
+fi
+
+# Install matlabengine first from MATLAB installation
+echo -e "\nInstalling MATLAB engine"
+cd "$MATLAB_PATH/extern/engines/python"
+python -m pip install .
+cd "$SCRIPT_DIR"
+
+# Build and install the package with pip
+echo -e "\nBuilding and installing matlab-mcp-server with pip"
+pip install -e .
+
+# Test if the installation was successful
+echo -e "\nTesting installation"
+if command -v matlab-mcp-server &> /dev/null; then
+    echo "Installation successful! matlab-mcp-server is available in PATH"
+else
+    echo "Warning: matlab-mcp-server not found in PATH"
+    echo "Please check the logs for more information"
+    exit 1
+fi
+
+# Update the MCP configuration
+echo -e "\nUpdating MCP configuration"
+cat > mcp-pip.json << EOF
+{
+  "mcpServers": {
+    "matlab": {
+      "command": "matlab-mcp-server",
+      "args": [],
+      "env": {
+        "MATLAB_PATH": "${MATLAB_PATH}",
+        "PATH": "${MATLAB_PATH}/bin:${PATH}"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "list_tools",
+        "get_script_sections"
+      ]
+    }
+  }
+}
+EOF
+
+echo -e "\nSetup complete!"
+echo "To use the MATLAB MCP server with Cursor/Cline, copy the provided configuration:"
+echo "cp mcp-pip.json ~/.cursor/mcp.json"
+echo ""
+echo "To manually start the server, run:"
+echo "matlab-mcp-server"

--- a/test-pip-matlab-mcp.sh
+++ b/test-pip-matlab-mcp.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+# Test if matlab-mcp-server is available
+echo -e "\n=== Testing Installation ==="
+if command -v matlab-mcp-server &> /dev/null; then
+    echo "matlab-mcp-server is available in PATH"
+else
+    echo "Error: matlab-mcp-server not found in PATH"
+    echo "Please run ./setup-pip-matlab-mcp.sh first"
+    exit 1
+fi
+
+# Create a test MATLAB script
+echo -e "\n=== Setting up Test Files ==="
+echo "Creating a simple test script..."
+
+# Create a test MATLAB script if it doesn't exist
+EXAMPLE_DIR="examples/matlab_scripts"
+mkdir -p "$EXAMPLE_DIR"
+
+TEST_SCRIPT="$EXAMPLE_DIR/test_plot.m"
+if [ ! -f "$TEST_SCRIPT" ]; then
+  cat > "$TEST_SCRIPT" << 'EOF'
+% Simple test script for MATLAB MCP
+x = linspace(0, 2*pi, 100);
+y = sin(x);
+
+% Create a figure with some styling
+figure;
+plot(x, y, 'LineWidth', 2);
+title('Sine Wave');
+xlabel('x');
+ylabel('sin(x)');
+grid on;
+
+% Add some annotations
+text(pi, 0, '\leftarrow \pi', 'FontSize', 12);
+
+disp('Script executed successfully!')
+EOF
+fi
+
+# Test if matlabengine is installed
+echo -e "\n=== Testing MATLAB Engine Installation ==="
+MATLAB_PATH=${MATLAB_PATH:-"/Applications/MATLAB_R2024b.app"}
+export PATH="$MATLAB_PATH/bin:$PATH"
+python -c "import matlab.engine; print('MATLAB engine is properly installed')" || echo "Warning: MATLAB engine not properly installed"
+
+# Test starting the server
+echo -e "\n=== Testing Server Startup ==="
+echo "Starting the server in the background (will terminate after 5 seconds)..."
+matlab-mcp-server &
+SERVER_PID=$!
+sleep 5
+kill $SERVER_PID 2>/dev/null || true
+
+echo -e "\n=== Test Complete ==="
+echo "The installation has been tested successfully."
+echo "To use the MATLAB MCP server with Cursor/Cline, copy the provided configuration:"
+echo "cp mcp-pip.json ~/.cursor/mcp.json"
+echo ""
+echo "To manually start the server, run:"
+echo "matlab-mcp-server"


### PR DESCRIPTION
This PR addresses Issue #3 where Cursor fails to run with Python commands. The changes implement a simplified pip-based installation process and better documentation for environment setup.

### Changes
1. **Installation Process**
   - Moved to a pip-based installation approach
   - Created new `setup-pip-matlab-mcp.sh` script for automated setup
   - Added proper environment variable handling for MATLAB path
   - Removed Conda dependency in favor of direct pip installation

2. **Configuration**
   - Added template MCP configuration file (`mcp-pip.json`)
   - Updated configuration instructions for both Cursor and Cline
   - Added auto-approve settings for common commands
   - Improved environment variable handling in configuration

3. **Documentation**
   - Added detailed troubleshooting section
   - Simplified installation instructions
   - Added platform-specific guidance (Windows/macOS)
   - Added documentation about Python/MATLAB version compatibility
   - Improved license information

4. **Technical Changes**
   - Renamed entry point from `matlab-mcp` to `matlab-mcp-server` for clarity
   - Updated pyproject.toml configuration
   - Added mcp-pip.json to .gitignore

### Testing
The changes have been tested with:
- Fresh installation using pip
- Different MATLAB installations (default and custom paths)
- Both Cursor and Cline clients

### Notes
- Users should set their MATLAB_PATH environment variable if MATLAB is not in the default location
- Windows users need to run the setup script with admin privileges
- The installation process is now simpler and more straightforward with pip

Fixes #3