### PR TITLE
Fix MATLAB script extension handling

### DIFF
--- a/src/matlab_mcp/server.py
+++ b/src/matlab_mcp/server.py
@@ -285,10 +285,17 @@ async def create_matlab_script(
     server = MatlabServer.get_instance()
     await server.initialize()
 
-    if not script_name.isidentifier():
+    # Remove .m extension if present for validation
+    base_name = script_name[:-2] if script_name.endswith('.m') else script_name
+
+    if not base_name.isidentifier():
         raise ValueError("Script name must be a valid MATLAB identifier")
 
-    script_path = server.scripts_dir / f"{script_name}"
+    # Ensure .m extension is present
+    if not script_name.endswith('.m'):
+        script_name = f"{script_name}.m"
+
+    script_path = server.scripts_dir / script_name
     script_path.write_text(code)
 
     if ctx:


### PR DESCRIPTION
This PR improves MATLAB script name handling:
   - Properly validates script names by removing .m extension before validation
   - Ensures .m extension is present in final script name
   - Fixes potential issues with script name validation

### Technical Details:
- Modified `create_matlab_script` function to properly handle `.m` extensions
- Updated `setup-pip-matlab-mcp.sh` to use `uv pip` instead of regular `pip`
- Added validation to ensure script names are valid MATLAB identifiers

### Testing:
The changes have been tested with:
- Script names with and without .m extension
- Script names containing valid and invalid MATLAB identifiers