### PR TITLE
Add MATLAB type converters module (Issue #22)

### DIFF
--- a/src/matlab_mcp/__init__.py
+++ b/src/matlab_mcp/__init__.py
@@ -1,3 +1,19 @@
 """MATLAB MCP Tool - A Model Context Protocol server for MATLAB integration."""
 
 __version__ = "0.1.0"
+
+from matlab_mcp.converters import (
+    AttrDict,
+    ConversionConfig,
+    MatlabConverter,
+    convert_matlab_value,
+    convert_workspace,
+)
+
+__all__ = [
+    "AttrDict",
+    "ConversionConfig",
+    "MatlabConverter",
+    "convert_matlab_value",
+    "convert_workspace",
+]

--- a/src/matlab_mcp/converters.py
+++ b/src/matlab_mcp/converters.py
@@ -1,0 +1,393 @@
+"""Centralized MATLAB type converters for automatic dict serialization.
+
+This module provides converters similar to scipy.io.loadmat and mat73 for
+converting MATLAB types (matlab.double, matlab.struct, etc.) to Python
+native types.
+
+References:
+- scipy.io.loadmat: https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.loadmat.html
+- mat73: https://github.com/skjerns/mat7.3
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import matlab
+
+
+class AttrDict(dict):
+    """Dict that allows attribute-style access like MATLAB structs.
+
+    This provides a familiar interface for users coming from MATLAB,
+    where struct fields are accessed as attributes (e.g., s.field).
+
+    Example:
+        >>> d = AttrDict({'x': 1, 'y': 2})
+        >>> d.x
+        1
+        >>> d['x']
+        1
+    """
+
+    def __getattr__(self, key: str) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{key}'"
+            ) from None
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        self[key] = value
+
+    def __delattr__(self, key: str) -> None:
+        try:
+            del self[key]
+        except KeyError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{key}'"
+            ) from None
+
+
+@dataclass
+class ConversionConfig:
+    """Configuration for MATLAB type conversion.
+
+    Attributes:
+        max_array_size: Arrays larger than this become summaries with metadata.
+            Set to None for no limit (convert all arrays fully).
+        squeeze_matrices: Remove singleton dimensions from arrays.
+        use_attrdict: Use AttrDict for structs (enables attribute-style access).
+        include_metadata: Add _type, _size fields for truncated/large values.
+        depth_limit: Maximum recursion depth for nested structures.
+        sample_size: Number of elements to include in large array samples.
+    """
+
+    max_array_size: int = 1000
+    squeeze_matrices: bool = True
+    use_attrdict: bool = False
+    include_metadata: bool = True
+    depth_limit: int = 10
+    sample_size: int = 100
+
+
+class MatlabConverter:
+    """Convert MATLAB types to Python native types.
+
+    This converter handles recursive conversion of MATLAB values including:
+    - matlab.double arrays (to lists or summaries)
+    - MATLAB structs (to dicts or AttrDicts)
+    - Nested structures (recursive conversion with depth limit)
+    - Cell arrays (to lists)
+
+    Example:
+        >>> converter = MatlabConverter()
+        >>> result = converter.convert(matlab_value)
+
+        >>> # With custom config
+        >>> config = ConversionConfig(max_array_size=500, use_attrdict=True)
+        >>> converter = MatlabConverter(config)
+        >>> result = converter.convert(matlab_struct)
+    """
+
+    def __init__(self, config: Optional[ConversionConfig] = None):
+        """Initialize converter with configuration.
+
+        Args:
+            config: Conversion configuration. Uses defaults if None.
+        """
+        self.config = config or ConversionConfig()
+
+    def convert(self, value: Any, depth: Optional[int] = None) -> Any:
+        """Recursively convert MATLAB value to Python native types.
+
+        Args:
+            value: MATLAB value to convert (matlab.double, struct, etc.)
+            depth: Current recursion depth. Uses config.depth_limit if None.
+
+        Returns:
+            Python native type (dict, list, float, str, etc.)
+        """
+        if depth is None:
+            depth = self.config.depth_limit
+
+        # Handle None
+        if value is None:
+            return None
+
+        # Handle primitive types first (these don't need depth checks)
+        if isinstance(value, (int, float, bool)):
+            return value
+
+        if isinstance(value, str):
+            return value
+
+        # For complex types, check depth limit
+        if depth <= 0:
+            return self._make_truncated_value(value)
+
+        # Handle matlab.double arrays
+        if isinstance(value, matlab.double):
+            return self._convert_array(value)
+
+        # Handle MATLAB struct (has _fieldnames attribute)
+        if hasattr(value, "_fieldnames"):
+            return self._convert_struct(value, depth)
+
+        # Handle dict (recursive conversion)
+        if isinstance(value, dict):
+            return self._convert_dict(value, depth)
+
+        # Handle list/tuple (recursive conversion)
+        if isinstance(value, (list, tuple)):
+            return self._convert_sequence(value, depth)
+
+        # Handle other matlab types with _data attribute
+        if hasattr(value, "_data"):
+            return self._convert_matlab_data(value)
+
+        # Fallback: convert to string representation
+        return str(value)
+
+    def _convert_array(self, arr: matlab.double) -> Any:
+        """Convert matlab.double array to list or summary.
+
+        Args:
+            arr: MATLAB double array
+
+        Returns:
+            List of values, or dict summary for large arrays
+        """
+        size = arr.size
+        total_elements = 1
+        for dim in size:
+            total_elements *= dim
+
+        # Check if array should be converted fully or summarized
+        if (
+            self.config.max_array_size is not None
+            and total_elements > self.config.max_array_size
+        ):
+            return self._make_array_summary(arr, size, total_elements)
+
+        # Convert full array
+        return self._array_to_list(arr, size)
+
+    def _array_to_list(self, arr: matlab.double, size: tuple) -> Any:
+        """Convert array data to Python list.
+
+        Args:
+            arr: MATLAB array
+            size: Array dimensions
+
+        Returns:
+            Python list (possibly nested for multi-dimensional arrays)
+        """
+        # Handle different _data types (some MATLAB versions don't have tolist)
+        if hasattr(arr._data, "tolist"):
+            data = arr._data.tolist()
+        else:
+            data = list(arr._data)
+
+        # Squeeze singleton dimensions if configured
+        if self.config.squeeze_matrices and len(size) == 2:
+            if size[0] == 1 or size[1] == 1:
+                return data
+
+        # For 2D arrays, reshape to nested list
+        if len(size) == 2 and size[0] > 1 and size[1] > 1:
+            rows, cols = size
+            return [data[i * cols : (i + 1) * cols] for i in range(rows)]
+
+        return data
+
+    def _make_array_summary(
+        self, arr: matlab.double, size: tuple, total_elements: int
+    ) -> dict:
+        """Create summary dict for large arrays.
+
+        Args:
+            arr: MATLAB array
+            size: Array dimensions
+            total_elements: Total number of elements
+
+        Returns:
+            Dict with array metadata and sample data
+        """
+        # Get sample data
+        sample_size = min(self.config.sample_size, total_elements)
+        if hasattr(arr._data, "tolist"):
+            sample = arr._data[:sample_size].tolist()
+        else:
+            sample = list(arr._data)[:sample_size]
+
+        # Calculate statistics if possible
+        try:
+            data_list = list(arr._data)
+            stats = {
+                "min": min(data_list),
+                "max": max(data_list),
+                "mean": sum(data_list) / len(data_list),
+            }
+        except (TypeError, ValueError):
+            stats = None
+
+        summary = {
+            "_mcp_type": "large_array",
+            "dimensions": list(size),
+            "total_elements": total_elements,
+            "data_type": "double",
+            "sample_data": sample,
+        }
+
+        if stats:
+            summary["statistics"] = stats
+
+        if self.config.include_metadata:
+            summary["memory_usage_mb"] = round(total_elements * 8 / (1024 * 1024), 2)
+
+        return summary
+
+    def _convert_struct(self, struct: Any, depth: int) -> dict:
+        """Convert MATLAB struct to dict or AttrDict.
+
+        Args:
+            struct: MATLAB struct with _fieldnames attribute
+            depth: Current recursion depth
+
+        Returns:
+            Dict or AttrDict with converted field values
+        """
+        result = {}
+
+        for field_name in struct._fieldnames:
+            field_value = getattr(struct, field_name)
+            result[field_name] = self.convert(field_value, depth - 1)
+
+        if self.config.use_attrdict:
+            return AttrDict(result)
+
+        return result
+
+    def _convert_dict(self, d: dict, depth: int) -> dict:
+        """Recursively convert dict values.
+
+        Args:
+            d: Dictionary to convert
+            depth: Current recursion depth
+
+        Returns:
+            Dict with converted values
+        """
+        result = {k: self.convert(v, depth - 1) for k, v in d.items()}
+
+        if self.config.use_attrdict:
+            return AttrDict(result)
+
+        return result
+
+    def _convert_sequence(self, seq: Any, depth: int) -> list:
+        """Recursively convert list/tuple values.
+
+        Args:
+            seq: Sequence to convert
+            depth: Current recursion depth
+
+        Returns:
+            List with converted values
+        """
+        return [self.convert(item, depth - 1) for item in seq]
+
+    def _convert_matlab_data(self, value: Any) -> Any:
+        """Convert other MATLAB types with _data attribute.
+
+        Args:
+            value: MATLAB value with _data attribute
+
+        Returns:
+            Converted Python value
+        """
+        data = value._data
+        if hasattr(data, "tolist"):
+            return data.tolist()
+        elif hasattr(data, "__iter__"):
+            return list(data)
+        else:
+            return data
+
+    def _make_truncated_value(self, value: Any) -> dict:
+        """Create truncated value marker for depth limit.
+
+        Args:
+            value: Value that hit depth limit
+
+        Returns:
+            Dict indicating truncation
+        """
+        return {
+            "_mcp_truncated": True,
+            "_mcp_type": type(value).__name__,
+        }
+
+
+# Convenience functions for common use cases
+
+
+def convert_matlab_value(
+    value: Any,
+    max_array_size: int = 1000,
+    use_attrdict: bool = False,
+    depth_limit: int = 10,
+) -> Any:
+    """Convert a MATLAB value to Python native types.
+
+    This is a convenience function for one-off conversions.
+
+    Args:
+        value: MATLAB value to convert
+        max_array_size: Arrays larger than this become summaries
+        use_attrdict: Use AttrDict for structs
+        depth_limit: Maximum recursion depth
+
+    Returns:
+        Python native type
+
+    Example:
+        >>> result = convert_matlab_value(matlab_struct, use_attrdict=True)
+        >>> result.field_name  # Attribute-style access
+    """
+    config = ConversionConfig(
+        max_array_size=max_array_size,
+        use_attrdict=use_attrdict,
+        depth_limit=depth_limit,
+    )
+    converter = MatlabConverter(config)
+    return converter.convert(value)
+
+
+def convert_workspace(
+    workspace: dict,
+    max_array_size: int = 1000,
+    depth_limit: int = 10,
+) -> dict:
+    """Convert an entire MATLAB workspace to Python native types.
+
+    Args:
+        workspace: Dict of variable names to MATLAB values
+        max_array_size: Arrays larger than this become summaries
+        depth_limit: Maximum recursion depth
+
+    Returns:
+        Dict of variable names to Python native values
+
+    Example:
+        >>> workspace = engine.get_workspace()
+        >>> converted = convert_workspace(workspace)
+    """
+    config = ConversionConfig(
+        max_array_size=max_array_size,
+        depth_limit=depth_limit,
+    )
+    converter = MatlabConverter(config)
+
+    return {name: converter.convert(value) for name, value in workspace.items()}

--- a/src/matlab_mcp/engine.py
+++ b/src/matlab_mcp/engine.py
@@ -14,6 +14,7 @@ import matlab.engine
 from mcp.server.fastmcp import Context
 from PIL import Image
 
+from .converters import ConversionConfig, MatlabConverter
 from .models import (
     CompressionConfig,
     ConnectionStatus,
@@ -169,8 +170,17 @@ class MatlabEngine:
         self,
         config: Optional[PerformanceConfig] = None,
         workspace_config: Optional[WorkspaceConfig] = None,
+        conversion_config: Optional[ConversionConfig] = None,
     ):
-        """Initialize MATLAB engine wrapper."""
+        """Initialize MATLAB engine wrapper.
+
+        Args:
+            config: Performance and reliability configuration
+            workspace_config: Workspace optimization configuration
+            conversion_config: MATLAB type conversion configuration (optional).
+                If provided, uses the new centralized MatlabConverter for type
+                conversions. If None, uses legacy conversion methods.
+        """
         self.eng = None
         # Use .mcp directory in home for all outputs
         self.mcp_dir = Path.home() / ".mcp"
@@ -189,6 +199,12 @@ class MatlabEngine:
         self.connection_start_time = time.time()
         self.connection_id = str(uuid.uuid4())
         self.last_activity = time.time()
+
+        # Type conversion configuration
+        self.conversion_config = conversion_config
+        self.converter = (
+            MatlabConverter(conversion_config) if conversion_config else None
+        )
 
         # Connection pool for improved performance
         self.connection_pool = MatlabConnectionPool()
@@ -1172,10 +1188,29 @@ class MatlabEngine:
         except Exception:
             return None
 
+    def convert_value(self, value: Any, depth: int = 1, max_elements: int = 100) -> Any:
+        """Convert MATLAB value to Python using configured converter.
+
+        If a conversion_config was provided at initialization, uses the new
+        centralized MatlabConverter. Otherwise, falls back to legacy conversion.
+
+        Args:
+            value: MATLAB value to convert
+            depth: Maximum recursion depth for nested structures
+            max_elements: Maximum array elements before summarizing
+
+        Returns:
+            Python native type (dict, list, float, str, etc.)
+        """
+        if self.converter is not None:
+            return self.converter.convert(value, depth)
+        else:
+            return self._convert_matlab_value(value, depth, max_elements)
+
     def _convert_matlab_value(
         self, value, depth: int = 1, max_elements: int = 100
     ) -> any:
-        """Convert MATLAB value to Python with depth and size limits.
+        """Convert MATLAB value to Python with depth and size limits (legacy).
 
         Args:
             value: MATLAB value to convert

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,379 @@
+"""Tests for MATLAB type converters module."""
+
+import pytest
+
+from matlab_mcp.converters import (
+    AttrDict,
+    ConversionConfig,
+    MatlabConverter,
+    convert_matlab_value,
+    convert_workspace,
+)
+
+
+class TestAttrDict:
+    """Tests for AttrDict class."""
+
+    def test_dict_access(self):
+        """Test standard dict access."""
+        d = AttrDict({"x": 1, "y": 2})
+
+        assert d["x"] == 1
+        assert d["y"] == 2
+
+    def test_attribute_access(self):
+        """Test attribute-style access."""
+        d = AttrDict({"x": 1, "y": 2})
+
+        assert d.x == 1
+        assert d.y == 2
+
+    def test_attribute_set(self):
+        """Test setting via attribute."""
+        d = AttrDict()
+        d.x = 10
+        d.y = 20
+
+        assert d["x"] == 10
+        assert d.y == 20
+
+    def test_attribute_delete(self):
+        """Test deleting via attribute."""
+        d = AttrDict({"x": 1, "y": 2})
+        del d.x
+
+        assert "x" not in d
+        assert d.y == 2
+
+    def test_missing_attribute_error(self):
+        """Test AttributeError for missing key."""
+        d = AttrDict({"x": 1})
+
+        with pytest.raises(AttributeError):
+            _ = d.nonexistent
+
+    def test_delete_missing_attribute_error(self):
+        """Test AttributeError when deleting missing key."""
+        d = AttrDict({"x": 1})
+
+        with pytest.raises(AttributeError):
+            del d.nonexistent
+
+    def test_nested_attrdict(self):
+        """Test nested AttrDict access."""
+        d = AttrDict({"outer": AttrDict({"inner": 42})})
+
+        assert d.outer.inner == 42
+
+
+class TestConversionConfig:
+    """Tests for ConversionConfig class."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = ConversionConfig()
+
+        assert config.max_array_size == 1000
+        assert config.squeeze_matrices is True
+        assert config.use_attrdict is False
+        assert config.include_metadata is True
+        assert config.depth_limit == 10
+        assert config.sample_size == 100
+
+    def test_custom_config(self):
+        """Test custom configuration values."""
+        config = ConversionConfig(
+            max_array_size=500,
+            squeeze_matrices=False,
+            use_attrdict=True,
+            include_metadata=False,
+            depth_limit=5,
+            sample_size=50,
+        )
+
+        assert config.max_array_size == 500
+        assert config.squeeze_matrices is False
+        assert config.use_attrdict is True
+        assert config.include_metadata is False
+        assert config.depth_limit == 5
+        assert config.sample_size == 50
+
+
+class TestMatlabConverterBasic:
+    """Tests for MatlabConverter with basic types."""
+
+    def test_convert_none(self):
+        """Test converting None."""
+        converter = MatlabConverter()
+
+        assert converter.convert(None) is None
+
+    def test_convert_string(self):
+        """Test converting string."""
+        converter = MatlabConverter()
+
+        assert converter.convert("hello") == "hello"
+
+    def test_convert_int(self):
+        """Test converting integer."""
+        converter = MatlabConverter()
+
+        assert converter.convert(42) == 42
+
+    def test_convert_float(self):
+        """Test converting float."""
+        converter = MatlabConverter()
+
+        assert converter.convert(3.14) == 3.14
+
+    def test_convert_bool(self):
+        """Test converting boolean."""
+        converter = MatlabConverter()
+
+        assert converter.convert(True) is True
+        assert converter.convert(False) is False
+
+    def test_convert_list(self):
+        """Test converting list."""
+        converter = MatlabConverter()
+
+        result = converter.convert([1, 2, 3])
+        assert result == [1, 2, 3]
+
+    def test_convert_dict(self):
+        """Test converting dict."""
+        converter = MatlabConverter()
+
+        result = converter.convert({"a": 1, "b": 2})
+        assert result == {"a": 1, "b": 2}
+
+    def test_convert_nested_dict(self):
+        """Test converting nested dict."""
+        converter = MatlabConverter()
+
+        result = converter.convert({"outer": {"inner": 42}})
+        assert result == {"outer": {"inner": 42}}
+
+
+class TestMatlabConverterWithAttrDict:
+    """Tests for MatlabConverter with AttrDict output."""
+
+    def test_dict_to_attrdict(self):
+        """Test converting dict to AttrDict."""
+        config = ConversionConfig(use_attrdict=True)
+        converter = MatlabConverter(config)
+
+        result = converter.convert({"x": 1, "y": 2})
+
+        assert isinstance(result, AttrDict)
+        assert result.x == 1
+        assert result.y == 2
+
+    def test_nested_attrdict(self):
+        """Test nested AttrDict conversion."""
+        config = ConversionConfig(use_attrdict=True)
+        converter = MatlabConverter(config)
+
+        result = converter.convert({"outer": {"inner": 42}})
+
+        assert isinstance(result, AttrDict)
+        assert isinstance(result.outer, AttrDict)
+        assert result.outer.inner == 42
+
+
+class TestMatlabConverterDepthLimit:
+    """Tests for depth limit handling."""
+
+    def test_depth_limit_truncation(self):
+        """Test that depth limit causes truncation."""
+        config = ConversionConfig(depth_limit=2)
+        converter = MatlabConverter(config)
+
+        # With depth=2: outer(depth=2) -> inner(depth=1) -> deep(depth=0, truncated)
+        result = converter.convert({"outer": {"inner": {"deep": 1}}})
+
+        # The innermost "deep" dict should be truncated
+        assert result["outer"]["inner"]["_mcp_truncated"] is True
+
+    def test_custom_depth_in_call(self):
+        """Test passing custom depth to convert call."""
+        converter = MatlabConverter()
+
+        # With depth=0, should immediately truncate
+        result = converter.convert({"x": 1}, depth=0)
+
+        assert result["_mcp_truncated"] is True
+
+    def test_depth_limit_preserves_values(self):
+        """Test that depth limit preserves primitive values."""
+        config = ConversionConfig(depth_limit=1)
+        converter = MatlabConverter(config)
+
+        # depth=1 allows one level of dict, but nested dicts get truncated
+        result = converter.convert({"x": 1, "nested": {"y": 2}})
+
+        assert result["x"] == 1
+        assert result["nested"]["_mcp_truncated"] is True
+
+
+class TestMatlabConverterWithMatlab:
+    """Tests for MatlabConverter with actual MATLAB types."""
+
+    @pytest.mark.asyncio
+    async def test_convert_matlab_double(self, matlab_engine):
+        """Test converting matlab.double array."""
+        await matlab_engine.execute("test_arr = [1, 2, 3, 4, 5];", capture_plots=False)
+
+        # Get raw value
+
+        raw_value = matlab_engine.eng.workspace["test_arr"]
+
+        converter = MatlabConverter()
+        result = converter.convert(raw_value)
+
+        assert isinstance(result, list)
+        assert result == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    @pytest.mark.asyncio
+    async def test_convert_matlab_struct(self, matlab_engine):
+        """Test converting MATLAB struct."""
+        await matlab_engine.execute(
+            "test_struct.x = 10; test_struct.y = 20;", capture_plots=False
+        )
+
+        raw_value = matlab_engine.eng.workspace["test_struct"]
+
+        converter = MatlabConverter()
+        result = converter.convert(raw_value)
+
+        assert isinstance(result, dict)
+        assert result["x"] == 10.0
+        assert result["y"] == 20.0
+
+    @pytest.mark.asyncio
+    async def test_convert_nested_struct(self, matlab_engine):
+        """Test converting nested MATLAB struct."""
+        await matlab_engine.execute("nested.level1.value = 42;", capture_plots=False)
+
+        raw_value = matlab_engine.eng.workspace["nested"]
+
+        converter = MatlabConverter()
+        result = converter.convert(raw_value)
+
+        assert isinstance(result, dict)
+        assert result["level1"]["value"] == 42.0
+
+    @pytest.mark.asyncio
+    async def test_convert_large_array_summary(self, matlab_engine):
+        """Test that large arrays become summaries."""
+        await matlab_engine.execute("large_arr = ones(100, 100);", capture_plots=False)
+
+        raw_value = matlab_engine.eng.workspace["large_arr"]
+
+        # Use small max_array_size to trigger summary
+        config = ConversionConfig(max_array_size=100)
+        converter = MatlabConverter(config)
+        result = converter.convert(raw_value)
+
+        assert isinstance(result, dict)
+        assert result["_mcp_type"] == "large_array"
+        assert result["total_elements"] == 10000
+        assert "sample_data" in result
+        assert "statistics" in result
+
+    @pytest.mark.asyncio
+    async def test_convert_struct_to_attrdict(self, matlab_engine):
+        """Test converting struct with AttrDict enabled."""
+        await matlab_engine.execute(
+            "attr_s.name = 'test'; attr_s.value = 123;", capture_plots=False
+        )
+
+        raw_value = matlab_engine.eng.workspace["attr_s"]
+
+        config = ConversionConfig(use_attrdict=True)
+        converter = MatlabConverter(config)
+        result = converter.convert(raw_value)
+
+        assert isinstance(result, AttrDict)
+        assert result.name == "test"
+        assert result.value == 123.0
+
+
+class TestConvenienceFunctions:
+    """Tests for convenience functions."""
+
+    def test_convert_matlab_value_basic(self):
+        """Test convert_matlab_value with basic type."""
+        result = convert_matlab_value({"x": 1, "y": 2})
+
+        assert result == {"x": 1, "y": 2}
+
+    def test_convert_matlab_value_with_attrdict(self):
+        """Test convert_matlab_value with AttrDict."""
+        result = convert_matlab_value({"x": 1}, use_attrdict=True)
+
+        assert isinstance(result, AttrDict)
+        assert result.x == 1
+
+    def test_convert_workspace_basic(self):
+        """Test convert_workspace with basic types."""
+        workspace = {"var1": 1, "var2": "hello", "var3": [1, 2, 3]}
+
+        result = convert_workspace(workspace)
+
+        assert result == {"var1": 1, "var2": "hello", "var3": [1, 2, 3]}
+
+
+class TestEngineWithConverter:
+    """Tests for MatlabEngine with converter integration."""
+
+    @pytest.mark.asyncio
+    async def test_engine_with_conversion_config(self):
+        """Test creating engine with conversion config."""
+        from matlab_mcp.engine import MatlabEngine
+
+        config = ConversionConfig(use_attrdict=True, max_array_size=500)
+        engine = MatlabEngine(conversion_config=config)
+
+        await engine.initialize()
+
+        try:
+            assert engine.converter is not None
+            assert engine.conversion_config is not None
+            assert engine.conversion_config.use_attrdict is True
+        finally:
+            engine.close()
+
+    @pytest.mark.asyncio
+    async def test_engine_convert_value_method(self, matlab_engine):
+        """Test engine's convert_value method."""
+        await matlab_engine.execute("cv_test = [1, 2, 3];", capture_plots=False)
+
+        raw_value = matlab_engine.eng.workspace["cv_test"]
+
+        # Using legacy conversion (no converter configured)
+        result = matlab_engine.convert_value(raw_value)
+
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_engine_with_converter_converts_structs(self):
+        """Test engine with converter handles structs correctly."""
+        from matlab_mcp.engine import MatlabEngine
+
+        config = ConversionConfig(use_attrdict=True, depth_limit=5)
+        engine = MatlabEngine(conversion_config=config)
+
+        await engine.initialize()
+
+        try:
+            await engine.execute("conv_s.a = 1; conv_s.b = 2;", capture_plots=False)
+
+            raw_value = engine.eng.workspace["conv_s"]
+            # Use higher depth to fully convert struct fields
+            result = engine.convert_value(raw_value, depth=5)
+
+            assert isinstance(result, AttrDict)
+            assert result.a == 1.0
+        finally:
+            engine.close()


### PR DESCRIPTION
## Summary
- Add centralized converters.py module with scipy.io.loadmat style conversion
- Implement MatlabConverter, AttrDict, and ConversionConfig classes
- Integrate with MatlabEngine via conversion_config parameter
- Support configurable array size limits, depth limits, and AttrDict output

## Changes
- **converters.py**: New module with MatlabConverter, AttrDict, ConversionConfig
- **engine.py**: Add convert_value method and converter integration
- **__init__.py**: Export converter classes and functions
- **test_converters.py**: 33 comprehensive tests

## Test plan
- [x] All 155 tests passing
- [x] Coverage at 63% (converters at 78%)
- [x] AttrDict attribute access works
- [x] Large array summaries work correctly
- [x] Depth limits prevent infinite recursion

Closes #22