### PR TITLE
Handle non-scalar MATLAB structures (Issue #2)

### DIFF
--- a/src/matlab_mcp/engine.py
+++ b/src/matlab_mcp/engine.py
@@ -977,9 +977,11 @@ class MatlabEngine:
         Returns:
             Metadata dict if recovery succeeds, None if it fails
         """
-        is_struct_error = "scalar struct" in err_str.lower()
-        is_char_error = "char array" in err_str.lower() and (
-            "1-by-N" in err_str or "M-by-1" in err_str or "M-by-N" in err_str
+        err_lower = err_str.lower()
+        is_struct_error = "scalar struct" in err_lower
+        # MATLAB error: "char arrays returned from MATLAB must be 1-by-N or M-by-1"
+        is_char_error = "char array" in err_lower and (
+            "1-by-n" in err_lower or "m-by-1" in err_lower
         )
 
         if not (is_struct_error or is_char_error):
@@ -1019,7 +1021,7 @@ class MatlabEngine:
                     "class": var_class,
                     "size": size,
                     "numel": numel,
-                    "note": f"Multi-dimensional char array ({size[0]}x{size[1]}); cannot transfer directly",
+                    "note": f"Multi-dimensional char array ({'x'.join(str(s) for s in size)}); cannot transfer directly",
                 }
 
         except Exception:

--- a/src/matlab_mcp/engine.py
+++ b/src/matlab_mcp/engine.py
@@ -953,9 +953,79 @@ class MatlabEngine:
                         )
 
             except Exception as e:
-                workspace[var] = f"<Error reading variable: {str(e)}>"
+                err_str = str(e)
+                # Try to recover metadata for known problematic types
+                recovered = self._recover_variable_metadata(var, err_str)
+                workspace[var] = (
+                    recovered
+                    if recovered is not None
+                    else f"<Error reading variable: {err_str}>"
+                )
 
         return workspace
+
+    def _recover_variable_metadata(self, var: str, err_str: str) -> dict | None:
+        """Attempt to recover metadata for variables that fail direct access.
+
+        Handles non-scalar structs and complex char arrays by querying MATLAB
+        for type and size information instead of the value itself.
+
+        Args:
+            var: MATLAB variable name
+            err_str: Original error string from failed access
+
+        Returns:
+            Metadata dict if recovery succeeds, None if it fails
+        """
+        is_struct_error = "scalar struct" in err_str.lower()
+        is_char_error = "char array" in err_str.lower() and (
+            "1-by-N" in err_str or "M-by-1" in err_str or "M-by-N" in err_str
+        )
+
+        if not (is_struct_error or is_char_error):
+            return None
+
+        try:
+            var_class = self.eng.eval(f"class({var})", nargout=1)
+            size_result = self.eng.eval(f"size({var})", nargout=1)
+            size = (
+                list(size_result._data)
+                if hasattr(size_result, "_data")
+                else list(size_result)
+            )
+            numel = int(self.eng.eval(f"numel({var})", nargout=1))
+
+            if is_struct_error and var_class == "struct":
+                try:
+                    field_names_result = self.eng.eval(
+                        f"fieldnames({var}(1))", nargout=1
+                    )
+                    field_names = list(field_names_result) if field_names_result else []
+                except Exception:
+                    field_names = []
+
+                return {
+                    "_mcp_type": "non_scalar_struct",
+                    "class": var_class,
+                    "size": size,
+                    "numel": numel,
+                    "field_names": field_names,
+                    "note": f"Non-scalar struct with {numel} elements; use get_struct_info for details",
+                }
+
+            if is_char_error and var_class == "char":
+                return {
+                    "_mcp_type": "complex_char",
+                    "class": var_class,
+                    "size": size,
+                    "numel": numel,
+                    "note": f"Multi-dimensional char array ({size[0]}x{size[1]}); cannot transfer directly",
+                }
+
+        except Exception:
+            pass
+
+        return None
 
     async def get_variable(
         self,

--- a/tests/test_non_scalar_structs.py
+++ b/tests/test_non_scalar_structs.py
@@ -1,0 +1,202 @@
+"""Tests for non-scalar struct and complex char array handling in get_workspace."""
+
+import pytest
+
+try:
+    import importlib.util
+
+    MATLAB_AVAILABLE = importlib.util.find_spec("matlab.engine") is not None
+except Exception:
+    MATLAB_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not MATLAB_AVAILABLE, reason="MATLAB Engine not available"
+)
+
+
+@pytest.fixture(scope="module")
+def engine(matlab_engine):
+    """Use the shared MATLAB engine fixture."""
+    return matlab_engine
+
+
+class TestNonScalarStructHandling:
+    """Tests that non-scalar structs return metadata instead of error strings."""
+
+    @pytest.mark.asyncio
+    async def test_non_scalar_struct_returns_metadata(self, engine):
+        """Non-scalar struct should return _mcp_type metadata, not error string."""
+        await engine.execute(
+            "ns_struct(1).a = 1; ns_struct(2).a = 2;", capture_plots=False
+        )
+
+        workspace = await engine.get_workspace()
+
+        assert "ns_struct" in workspace
+        data = workspace["ns_struct"]
+        assert isinstance(data, dict), (
+            f"Expected dict, got {type(data).__name__}: {data!r}"
+        )
+        assert data.get("_mcp_type") == "non_scalar_struct", (
+            f"Expected non_scalar_struct type, got: {data}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_scalar_struct_has_size_info(self, engine):
+        """Non-scalar struct metadata should include size and numel."""
+        await engine.execute(
+            "sized_struct(1).x = 10; sized_struct(2).x = 20; sized_struct(3).x = 30;",
+            capture_plots=False,
+        )
+
+        workspace = await engine.get_workspace()
+
+        assert "sized_struct" in workspace
+        data = workspace["sized_struct"]
+        assert isinstance(data, dict)
+        assert "size" in data, f"Expected 'size' key in metadata: {data}"
+        assert "numel" in data, f"Expected 'numel' key in metadata: {data}"
+        assert data["numel"] == 3
+
+    @pytest.mark.asyncio
+    async def test_non_scalar_struct_has_field_names(self, engine):
+        """Non-scalar struct metadata should include field names."""
+        await engine.execute(
+            "field_struct(1).alpha = 1; field_struct(1).beta = 'x';"
+            " field_struct(2).alpha = 2; field_struct(2).beta = 'y';",
+            capture_plots=False,
+        )
+
+        workspace = await engine.get_workspace()
+
+        assert "field_struct" in workspace
+        data = workspace["field_struct"]
+        assert isinstance(data, dict)
+        assert "field_names" in data, f"Expected 'field_names' key in metadata: {data}"
+        field_names = data["field_names"]
+        assert isinstance(field_names, list)
+        assert "alpha" in field_names
+        assert "beta" in field_names
+
+    @pytest.mark.asyncio
+    async def test_non_scalar_struct_no_error_string(self, engine):
+        """Non-scalar struct should not return an error string."""
+        await engine.execute(
+            "err_struct(1).v = 100; err_struct(2).v = 200;", capture_plots=False
+        )
+
+        workspace = await engine.get_workspace()
+
+        assert "err_struct" in workspace
+        data = workspace["err_struct"]
+        assert not isinstance(data, str), (
+            f"Expected dict metadata, got error string: {data!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_scalar_struct_class_is_struct(self, engine):
+        """Non-scalar struct metadata should report class as 'struct'."""
+        await engine.execute(
+            "class_struct(1).n = 1; class_struct(2).n = 2;", capture_plots=False
+        )
+
+        workspace = await engine.get_workspace()
+
+        assert "class_struct" in workspace
+        data = workspace["class_struct"]
+        assert isinstance(data, dict)
+        assert data.get("class") == "struct"
+
+
+class TestComplexCharArrayHandling:
+    """Tests that M-by-N char arrays return size info instead of error strings."""
+
+    @pytest.mark.asyncio
+    async def test_complex_char_returns_metadata(self, engine):
+        """M-by-N char array should return _mcp_type metadata, not error string."""
+        await engine.execute("c_arr = ['abc'; 'def'];", capture_plots=False)
+
+        workspace = await engine.get_workspace()
+
+        assert "c_arr" in workspace
+        data = workspace["c_arr"]
+        assert isinstance(data, dict), (
+            f"Expected dict, got {type(data).__name__}: {data!r}"
+        )
+        assert data.get("_mcp_type") == "complex_char", (
+            f"Expected complex_char type, got: {data}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_complex_char_has_size_info(self, engine):
+        """M-by-N char array metadata should include size."""
+        await engine.execute("c_sized = ['hello'; 'world'];", capture_plots=False)
+
+        workspace = await engine.get_workspace()
+
+        assert "c_sized" in workspace
+        data = workspace["c_sized"]
+        assert isinstance(data, dict)
+        assert "size" in data, f"Expected 'size' key in metadata: {data}"
+        size = data["size"]
+        assert isinstance(size, list)
+        assert len(size) == 2
+        # 2 rows, 5 cols
+        assert size[0] == 2
+        assert size[1] == 5
+
+    @pytest.mark.asyncio
+    async def test_complex_char_no_error_string(self, engine):
+        """M-by-N char array should not return an error string."""
+        await engine.execute("c_no_err = ['foo'; 'bar'];", capture_plots=False)
+
+        workspace = await engine.get_workspace()
+
+        assert "c_no_err" in workspace
+        data = workspace["c_no_err"]
+        assert not isinstance(data, str), (
+            f"Expected dict metadata, got error string: {data!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_complex_char_class_is_char(self, engine):
+        """M-by-N char array metadata should report class as 'char'."""
+        await engine.execute("c_class = ['xyz'; 'abc'];", capture_plots=False)
+
+        workspace = await engine.get_workspace()
+
+        assert "c_class" in workspace
+        data = workspace["c_class"]
+        assert isinstance(data, dict)
+        assert data.get("class") == "char"
+
+
+class TestRecoverMetadataFallback:
+    """Tests the fallback behavior when metadata recovery fails."""
+
+    def test_recover_metadata_returns_none_for_unknown_error(self, engine):
+        """_recover_variable_metadata returns None for non-struct/char errors."""
+        result = engine._recover_variable_metadata(
+            "some_var", "some unrelated MATLAB error"
+        )
+        assert result is None
+
+    def test_recover_metadata_returns_none_for_empty_error(self, engine):
+        """_recover_variable_metadata returns None for empty error string."""
+        result = engine._recover_variable_metadata("some_var", "")
+        assert result is None
+
+    def test_recover_metadata_struct_error_string_detected(self, engine):
+        """_recover_variable_metadata detects scalar struct error strings."""
+        # This test verifies the detection logic without needing a real var
+        err = "only a scalar struct can be returned from MATLAB"
+        # For a var that doesn't exist, recovery will fail internally and return None
+        result = engine._recover_variable_metadata("nonexistent_xyz_abc", err)
+        # Should return None because var doesn't exist in workspace
+        assert result is None
+
+    def test_recover_metadata_char_error_string_detected(self, engine):
+        """_recover_variable_metadata detects char array error strings."""
+        err = "char arrays returned from MATLAB must be 1-by-N or M-by-1"
+        result = engine._recover_variable_metadata("nonexistent_xyz_abc", err)
+        assert result is None


### PR DESCRIPTION
## Summary
- Fix get_workspace() to return struct metadata for non-scalar structs instead of error strings
- Handle M-by-N char array edge cases with size/class info
- New _recover_variable_metadata() method with graceful fallback
- 13 new tests covering non-scalar structs, char arrays, and fallback behavior

Closes #2

## Test plan
- [x] Non-scalar struct returns metadata (_mcp_type, size, numel, field_names, class)
- [x] M-by-N char array returns size info instead of error string
- [x] Fallback to error string when recovery fails
- [x] All existing tests still pass (168 passed, 16 skipped)