### PR TITLE
Fix section execution reliability (Issue #28)

### DIFF
--- a/src/matlab_mcp/engine.py
+++ b/src/matlab_mcp/engine.py
@@ -1616,11 +1616,18 @@ class MatlabEngine:
             raise ValueError(f"No sections found in {file_path}")
 
         # Find section by title (case-insensitive partial match)
-        search_title = section_title.lower().strip()
+        search_title = section_title.strip()
+        if not search_title:
+            raise ValueError(
+                "section_title must not be empty. "
+                "Use get_script_sections to see available section titles."
+            )
+
+        search_lower = search_title.lower()
         matching_sections = []
 
         for idx, (start_line, end_line, title) in enumerate(sections):
-            if search_title in title.lower():
+            if search_lower in title.lower():
                 matching_sections.append((idx, start_line, end_line, title))
 
         if not matching_sections:

--- a/src/matlab_mcp/server.py
+++ b/src/matlab_mcp/server.py
@@ -293,6 +293,9 @@ async def execute_section_by_index(
         if scripts_path.exists():
             script_path = scripts_path
 
+    if not script_path.exists():
+        raise FileNotFoundError(f"Script not found: {file_path}")
+
     if ctx:
         ctx.info(f"Executing section index {section_index}")
 
@@ -356,6 +359,9 @@ async def execute_section_by_title(
         scripts_path = server.scripts_dir / file_path
         if scripts_path.exists():
             script_path = scripts_path
+
+    if not script_path.exists():
+        raise FileNotFoundError(f"Script not found: {file_path}")
 
     if ctx:
         ctx.info(f"Finding and executing section: '{section_title}'")

--- a/src/matlab_mcp/utils/section_parser.py
+++ b/src/matlab_mcp/utils/section_parser.py
@@ -7,38 +7,61 @@ from typing import List, Tuple
 def parse_sections(file_path: Path) -> List[Tuple[int, int, str]]:
     """Parse a MATLAB script into sections.
 
+    Sections are delimited by lines starting with '%%'. The section title
+    is the text after '%%' on the same line (stripped of whitespace). Sections
+    with no title text (bare '%%') get an empty string title.
+
+    If code appears before the first '%%' marker, that code is collected as a
+    leading 'Main' section. If no '%%' markers exist at all, the entire file
+    is a single 'Main' section.
+
     Args:
         file_path: Path to the MATLAB script
 
     Returns:
         List of tuples containing (start_line, end_line, section_title)
-        for each section in the script. If no sections are found, returns
-        a single section spanning the entire file.
+        where line numbers are 0-based and end_line is inclusive.
+        If no sections are found, returns a single section spanning the
+        entire file titled 'Main'.
     """
     sections = []
     current_start = 0
     current_title = "Main"
+    found_section_marker = False
 
     with open(file_path) as f:
         lines = f.readlines()
 
+    if not lines:
+        # Empty file: return a degenerate section with identical start/end
+        return [(0, 0, "Main")]
+
     for i, line in enumerate(lines):
+        # Only treat %% at the start of a line as a section marker.
+        # Inline comments like "x = 1; %% note" are NOT section markers.
         if line.startswith("%%"):
-            # If we found a section marker, end the previous section
-            if current_start < i:
+            if not found_section_marker:
+                # First %% encountered
+                found_section_marker = True
+                if i > 0:
+                    # There is code before the first section marker; save it
+                    # as the leading 'Main' section.
+                    sections.append((current_start, i - 1, current_title))
+            else:
+                # End the previous section (which started at current_start)
                 sections.append((current_start, i - 1, current_title))
 
-            # Start a new section
+            # Start a new section at this %% line
             current_start = i
             # Extract section title (everything after %% on the same line)
             current_title = line[2:].strip()
 
-    # Add the final section
-    if current_start < len(lines):
-        sections.append((current_start, len(lines) - 1, current_title))
+    # Add the final section (or the only section when no %% was found)
+    sections.append((current_start, len(lines) - 1, current_title))
 
-    # If no sections were found, treat the entire file as one section
-    if not sections:
+    # If no %% markers were found, the single appended section is the whole file.
+    # Reset its title to 'Main' since current_title was never changed.
+    if not found_section_marker:
         sections = [(0, len(lines) - 1, "Main")]
 
     return sections
@@ -49,10 +72,14 @@ def extract_section(
 ) -> str:
     """Extract a section of MATLAB code from a file.
 
+    The returned code includes the %% marker line (if any) since MATLAB treats
+    it as a comment.  When maintain_workspace is False a 'clear;' statement is
+    prepended so the section runs in an isolated workspace.
+
     Args:
         file_path: Path to the MATLAB script
-        start_line: Starting line number (0-based)
-        end_line: Ending line number (0-based)
+        start_line: Starting line number (0-based, inclusive)
+        end_line: Ending line number (0-based, inclusive)
         maintain_workspace: Whether to maintain workspace variables
 
     Returns:
@@ -81,8 +108,8 @@ def get_section_info(file_path: Path) -> List[dict]:
         List of dictionaries containing section information:
         {
             'title': section title,
-            'start_line': starting line number,
-            'end_line': ending line number,
+            'start_line': starting line number (0-based),
+            'end_line': ending line number (0-based, inclusive),
             'preview': first non-comment line of the section
         }
     """

--- a/tests/test_section_execution.py
+++ b/tests/test_section_execution.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from matlab_mcp.utils.section_parser import parse_sections
+
 
 @pytest.fixture
 def sample_script_with_sections(tmp_path):
@@ -41,6 +43,90 @@ def eeglab_script():
     if not path.exists():
         pytest.skip("EEGLAB tutorial scripts not found")
     return path
+
+
+# ---------------------------------------------------------------------------
+# Parser-only tests (no MATLAB engine required)
+# ---------------------------------------------------------------------------
+
+
+class TestSectionParserEdgeCases:
+    """Edge-case tests for parse_sections that don't require MATLAB."""
+
+    def test_script_with_four_sections(self, sample_script_with_sections):
+        """Sample script should parse into exactly 4 sections."""
+        sections = parse_sections(sample_script_with_sections)
+        assert len(sections) == 4
+
+    def test_section_titles_correct(self, sample_script_with_sections):
+        """Section titles should be stripped and correctly extracted."""
+        sections = parse_sections(sample_script_with_sections)
+        titles = [s[2] for s in sections]
+        assert titles[0] == "Section 1 - Initialize"
+        assert titles[1] == "Section 2 - Plot Data"
+        assert titles[2] == "Section 3 - Compute Statistics"
+        assert titles[3] == "Final Section"
+
+    def test_sections_are_contiguous(self, sample_script_with_sections):
+        """Sections must cover all lines with no gap or overlap."""
+        sections = parse_sections(sample_script_with_sections)
+        for i in range(len(sections) - 1):
+            _, end, _ = sections[i]
+            next_start, _, _ = sections[i + 1]
+            assert end + 1 == next_start
+
+    def test_preamble_before_first_marker(self, tmp_path):
+        """Lines before the first %% marker are returned as a 'Main' section."""
+        content = """% Script header
+clear;
+%% Step 1
+x = 1;
+"""
+        script = tmp_path / "preamble.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert len(sections) == 2
+        assert sections[0][2] == "Main"
+        assert sections[0][0] == 0
+        assert sections[0][1] == 1  # lines 0 and 1
+        assert sections[1][2] == "Step 1"
+
+    def test_empty_title_section(self, tmp_path):
+        """Bare %% with no text should produce an empty-string title."""
+        content = """%% Section A
+x = 1;
+%%
+y = 2;
+"""
+        script = tmp_path / "empty_title.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert len(sections) == 2
+        assert sections[0][2] == "Section A"
+        assert sections[1][2] == ""
+
+    def test_inline_percent_percent_ignored(self, tmp_path):
+        """A %% not at the start of a line must not create a new section."""
+        content = """x = 1; %% inline comment
+%% Real Section
+y = 2;
+"""
+        script = tmp_path / "inline.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        # Line 0 has inline %% -> treated as preamble 'Main'
+        # Line 1 is the only real section marker
+        assert len(sections) == 2
+        assert sections[0][2] == "Main"
+        assert sections[1][2] == "Real Section"
+
+
+# ---------------------------------------------------------------------------
+# Engine tests (require MATLAB)
+# ---------------------------------------------------------------------------
 
 
 class TestGetScriptSections:
@@ -159,6 +245,19 @@ class TestExecuteSectionByIndex:
                 str(sample_script_with_sections), section_index=-1
             )
 
+    @pytest.mark.asyncio
+    async def test_error_message_includes_range(
+        self, matlab_engine, sample_script_with_sections
+    ):
+        """IndexError message must tell the user the valid range."""
+        with pytest.raises(IndexError) as exc_info:
+            await matlab_engine.execute_section_by_index(
+                str(sample_script_with_sections), section_index=100
+            )
+        msg = str(exc_info.value)
+        # Message should mention valid range (0 to N-1)
+        assert "0" in msg or "range" in msg.lower()
+
 
 class TestExecuteSectionByTitle:
     """Tests for execute_section_by_title functionality."""
@@ -226,6 +325,43 @@ class TestExecuteSectionByTitle:
                 section_title="Section",  # Matches multiple sections
             )
         assert "Multiple sections match" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_empty_title_raises_error(
+        self, matlab_engine, sample_script_with_sections
+    ):
+        """Test that an empty section_title raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            await matlab_engine.execute_section_by_title(
+                str(sample_script_with_sections),
+                section_title="",
+            )
+        assert "empty" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_title_raises_error(
+        self, matlab_engine, sample_script_with_sections
+    ):
+        """Test that a whitespace-only section_title raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            await matlab_engine.execute_section_by_title(
+                str(sample_script_with_sections),
+                section_title="   ",
+            )
+        assert "empty" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_error_message_lists_available_sections(
+        self, matlab_engine, sample_script_with_sections
+    ):
+        """Error for missing title should list the available section titles."""
+        with pytest.raises(ValueError) as exc_info:
+            await matlab_engine.execute_section_by_title(
+                str(sample_script_with_sections),
+                section_title="nonexistent_xyz",
+            )
+        msg = str(exc_info.value)
+        assert "Available sections" in msg
 
 
 class TestArbitraryFilePaths:

--- a/tests/test_section_parser_unit.py
+++ b/tests/test_section_parser_unit.py
@@ -84,6 +84,145 @@ class TestParseSections:
         for start, end, _ in sections:
             assert start <= end
 
+    def test_section_marker_at_first_line(self, tmp_path):
+        """Test script where %% is the very first line."""
+        content = """%% Only Section
+x = 1;
+y = 2;
+"""
+        script = tmp_path / "first_line.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert len(sections) == 1
+        assert sections[0][0] == 0
+        assert sections[0][2] == "Only Section"
+
+    def test_code_before_first_section_marker(self, tmp_path):
+        """Test that code before the first %% is captured as a 'Main' section."""
+        content = """x = 1;
+y = 2;
+%% Section A
+z = 3;
+%% Section B
+w = 4;
+"""
+        script = tmp_path / "preamble.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        # The leading code plus two explicit sections
+        assert len(sections) == 3
+        assert sections[0][2] == "Main"
+        # Main section covers lines 0 and 1
+        assert sections[0][0] == 0
+        assert sections[0][1] == 1
+        assert sections[1][2] == "Section A"
+        assert sections[2][2] == "Section B"
+
+    def test_empty_section_title(self, tmp_path):
+        """Test section with bare %% (no title text)."""
+        content = """%% Section 1
+x = 1;
+%%
+%% Section 3
+z = 3;
+"""
+        script = tmp_path / "empty_title.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert len(sections) == 3
+        assert sections[0][2] == "Section 1"
+        assert sections[1][2] == ""
+        assert sections[2][2] == "Section 3"
+
+    def test_back_to_back_section_markers(self, tmp_path):
+        """Test consecutive %% markers create single-line empty sections."""
+        content = """%% Section 1
+x = 1;
+%%
+%%
+%% Section 4
+z = 3;
+"""
+        script = tmp_path / "consecutive.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert len(sections) == 4
+        # The two empty sections each span exactly one line
+        assert sections[1][0] == sections[1][1]
+        assert sections[2][0] == sections[2][1]
+
+    def test_trailing_whitespace_in_title(self, tmp_path):
+        """Test that trailing whitespace in section titles is stripped."""
+        content = """%% Section 1
+x = 1;
+%% Section 2\t
+y = 2;
+"""
+        script = tmp_path / "trailing.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert sections[0][2] == "Section 1"
+        assert sections[1][2] == "Section 2"
+
+    def test_last_section_includes_all_remaining_lines(self, tmp_path):
+        """Test that the last section captures all remaining lines."""
+        content = """%% Section 1
+x = 1;
+%% Section 2
+y = 2;
+more = 3;
+last = 4;"""
+        script = tmp_path / "no_trailing_newline.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        assert len(sections) == 2
+        # Last section must reach the final line (5, 0-based)
+        assert sections[1][1] == 5
+
+    def test_inline_percent_percent_not_treated_as_section(self, tmp_path):
+        """Test that %% in the middle of a line is NOT a section marker."""
+        content = """x = 1; %% this is not a section
+%% Real Section
+y = 2;
+"""
+        script = tmp_path / "inline_marker.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+
+        # Only the line-initial %% creates a section
+        assert len(sections) == 2
+        assert sections[0][2] == "Main"
+        assert sections[1][2] == "Real Section"
+
+    def test_empty_file(self, tmp_path):
+        """Test parsing an empty file."""
+        script = tmp_path / "empty.m"
+        script.write_text("")
+        sections = parse_sections(script)
+
+        assert len(sections) == 1
+        assert sections[0][2] == "Main"
+
+    def test_sections_are_contiguous(self, script_with_sections):
+        """Test that sections cover lines without overlap or gap."""
+        sections = parse_sections(script_with_sections)
+
+        for i in range(len(sections) - 1):
+            _, end, _ = sections[i]
+            next_start, _, _ = sections[i + 1]
+            # Adjacent sections must share a boundary:
+            # end of section i is one before start of section i+1
+            assert end + 1 == next_start, (
+                f"Gap or overlap between section {i} (end={end}) "
+                f"and section {i + 1} (start={next_start})"
+            )
+
 
 class TestExtractSection:
     """Tests for extract_section function."""
@@ -106,6 +245,36 @@ class TestExtractSection:
         code = extract_section(script_with_sections, 0, 3)
 
         assert "clear;" not in code
+
+    def test_extract_section_includes_marker_line(self, tmp_path):
+        """Test that the %% marker line is included in the extracted code."""
+        content = """%% My Section
+x = 42;
+"""
+        script = tmp_path / "marker.m"
+        script.write_text(content)
+        # Section spans lines 0-1
+        code = extract_section(script, 0, 1)
+
+        assert "%% My Section" in code
+        assert "x = 42" in code
+
+    def test_extract_single_line_section(self, tmp_path):
+        """Test extracting a single-line section (bare %%)."""
+        content = """%% Section 1
+x = 1;
+%%
+%% Section 3
+z = 3;
+"""
+        script = tmp_path / "single_line.m"
+        script.write_text(content)
+        sections = parse_sections(script)
+        # Middle section is the bare %% at line 2
+        start, end, _ = sections[1]
+        assert start == end
+        code = extract_section(script, start, end)
+        assert code.strip().startswith("%%")
 
 
 class TestGetSectionInfo:
@@ -146,3 +315,16 @@ class TestGetSectionInfo:
         for i in range(len(info) - 1):
             # Current section end should be before next section start
             assert info[i]["end_line"] < info[i + 1]["start_line"]
+
+    def test_section_info_preamble_title(self, tmp_path):
+        """Test that code before the first %% reports title 'Main'."""
+        content = """x = 1;
+%% Named Section
+y = 2;
+"""
+        script = tmp_path / "preamble_info.m"
+        script.write_text(content)
+        info = get_section_info(script)
+
+        assert info[0]["title"] == "Main"
+        assert info[1]["title"] == "Named Section"


### PR DESCRIPTION
## Summary

- **Bug fix:** `parse_sections` now correctly handles code appearing before the first `%%` marker (captured as a 'Main' section) using an explicit `found_section_marker` flag, replacing the ambiguous `current_start < i` condition.
- **Bug fix:** Bare `%%` markers and back-to-back `%%` markers (empty sections) are handled correctly regardless of surrounding content.
- **Clarification:** Only a `%%` at the beginning of a line is treated as a section marker; inline occurrences like `x = 1; %% note` are ignored (this was already true in the original code but is now documented).
- **Empty-title guard:** `execute_section_by_title` now raises `ValueError` immediately when `section_title` is empty or whitespace-only, instead of producing a confusing 'Multiple sections match' error.
- **Consistency:** `execute_section_by_index` and `execute_section_by_title` in `server.py` now check file existence before delegating to the engine, matching the pattern in `execute_section`.
- **Tests:** Added edge-case tests to `test_section_parser_unit.py` and a new `TestSectionParserEdgeCases` class in `test_section_execution.py` that runs without MATLAB.

Closes #28

## Test plan

- [x] Section parser handles code before first %% marker (preamble as 'Main')
- [x] Empty section titles (bare %%) are correctly represented
- [x] Back-to-back %% markers produce separate single-line sections
- [x] Trailing whitespace in titles is stripped
- [x] Last section includes all remaining lines with no trailing newline
- [x] Empty/whitespace search title raises ValueError with clear message
- [x] execute_section_by_index raises IndexError with valid range in message
- [x] execute_section_by_title lists available sections in error message
- [x] All existing parser-only tests still pass