### PR TITLE
Comprehensive EEGLAB integration tests (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ grid on;
 text(pi, 0, '\leftarrow \pi', 'FontSize', 12);
 ```
 
-To execute this script using the MCP tool:
+To execute this script using the `execute_script` tool:
 ```json
 {
     "script": "test_plot.m",
-    "isFile": true
+    "is_file": true
 }
 ```
 
@@ -243,16 +243,23 @@ grid on;
 sgtitle('Signal Analysis');
 ```
 
-To execute specific sections:
+To execute specific sections using `execute_section_by_index`:
 ```json
 {
-    "filePath": "section_test.m",
-    "sectionStart": 1,
-    "sectionEnd": 2
+    "file_path": "section_test.m",
+    "section_index": 0
 }
 ```
 
-This will run sections 1 and 2, generating the data and calculating statistics. The output will include:
+Or by title using `execute_section_by_title`:
+```json
+{
+    "file_path": "section_test.m",
+    "section_title": "Data Generation"
+}
+```
+
+The output will include:
 ```
 Generated 100 data points
 Statistics:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MATLAB MCP Tool
 
-A Model Context Protocol (MCP) server that provides tools for developing and running MATLAB files. This tool integrates with Cline and other MCP-compatible clients to provide interactive MATLAB development capabilities.
+A Model Context Protocol (MCP) server that provides tools for developing and running MATLAB files. Integrates with Claude Code, Cursor, and other MCP-compatible clients.
 
 ## Prerequisites
 
@@ -10,16 +10,11 @@ A Model Context Protocol (MCP) server that provides tools for developing and run
 
 ## Features
 
-1. **Execute MATLAB Scripts**
-   - Run complete MATLAB scripts
-   - Execute individual script sections
-   - Maintain workspace context between executions
-   - Capture and display plots
-
-2. **Section-based Execution**
-   - Execute specific sections of MATLAB files
-   - Support for cell mode (%% delimited sections)
-   - Maintain workspace context between sections
+1. **Script Execution** - Run complete scripts, individual sections (by index, title, or line range), maintain workspace context between executions, capture plots
+2. **Workspace Management** - Get full workspace, retrieve specific variables with field/depth/size control, inspect struct metadata, list and filter variables by name pattern or type
+3. **Figure Analysis** - Extract figure metadata (axes, labels, legends), get raw plot data, prepare figures for LLM-based analysis with custom prompts
+4. **Code Quality** - Lint MATLAB code via `checkcode` with severity filtering, supports inline code and file paths
+5. **Script Management** - Create scripts, list sections with previews, read script content via MCP resource
 
 ## Installation
 
@@ -126,60 +121,48 @@ This is equivalent to running:
 python -m matlab_mcp.server
 ```
 
-You should see a startup message listing the available tools and confirming the server is running:
-```
-MATLAB MCP Server is running...
-Available tools:
-  - execute_script: Execute MATLAB code or script file
-  - execute_script_section: Execute specific sections of a MATLAB script
-  - get_script_sections: Get information about script sections
-  - create_matlab_script: Create a new MATLAB script
-  - get_workspace: Get current MATLAB workspace variables
+You should see a startup message confirming the server is running with 15 tools available.
 
-Use the tools with Cline or other MCP-compatible clients.
-```
+2. Configure your MCP client. For **Claude Code**, add to `.mcp.json`:
 
-2. Use the provided MCP configuration (see [Installation](#installation)) file to configure Cline/Cursor:
 ```json
 {
   "mcpServers": {
     "matlab": {
-      "command": "matlab-mcp-server",
-      "args": [],
+      "command": "/path/to/matlab-mcp-tools/.venv/bin/matlab-mcp-server",
       "env": {
-        "MATLAB_PATH": "${MATLAB_PATH}",
-        "PATH": "${MATLAB_PATH}/bin:${PATH}"
-      },
-      "disabled": false,
-      "autoApprove": [
-        "list_tools",
-        "get_script_sections"
-      ]
+        "MATLAB_PATH": "/Applications/MATLAB_R2024b.app"
+      }
     }
   }
 }
 ```
 
-Hint: You can find the MATLAB engine installation path by running `python -c "import matlab; print(matlab.__file__)"`.
+For **Cursor**, use the auto-generated `mcp-pip.json` or add to `~/.cursor/mcp.json`.
 
-3. Available Tools:
+Hint: Find the MATLAB engine path with `python -c "import matlab; print(matlab.__file__)"`.
 
-- **execute_matlab_script**
-  ```json
-  {
-    "script": "x = 1:10;\nplot(x, x.^2);",
-    "isFile": false
-  }
-  ```
+3. **Available Tools (15):**
 
-- **execute_matlab_section**
-  ```json
-  {
-    "filePath": "analysis.m",
-    "sectionStart": 1,
-    "sectionEnd": 10
-  }
-  ```
+| Category | Tool | Description |
+|----------|------|-------------|
+| Scripts | `execute_script` | Run MATLAB code or script file |
+| | `execute_section` | Execute by line range |
+| | `execute_section_by_index` | Execute by section index (0-based) |
+| | `execute_section_by_title` | Execute by section title (partial match) |
+| | `get_script_sections` | List sections with titles and previews |
+| | `create_matlab_script` | Create a new .m file |
+| Workspace | `get_workspace` | Get all workspace variables |
+| | `get_variable` | Get specific variable (with field/depth/size control) |
+| | `get_struct_info` | Get struct field metadata without data transfer |
+| | `list_workspace_variables` | List/filter variables by name pattern or type |
+| Figures | `get_figure_metadata` | Extract axes, labels, legends, subplot info |
+| | `get_plot_data` | Get raw x/y/z data from plot lines |
+| | `analyze_figure` | Prepare figure image + metadata for LLM analysis |
+| | `get_analysis_prompt` | Get/customize the figure analysis prompt |
+| Quality | `matlab_lint` | Run checkcode on code or files |
+
+**Resource:** `matlab://scripts/{script_name}` - Read script content
 
 ## Examples
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and fixtures for MATLAB MCP Tools tests."""
 
+import os
 import sys
 from pathlib import Path
 
@@ -9,12 +10,30 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 
+def _find_eeglab_path():
+    """Resolve EEGLAB installation path.
+
+    Check order: EEGLAB_PATH env var, ../eeg/eeglab, ../eeglab (legacy).
+    """
+    env_path = os.environ.get("EEGLAB_PATH")
+    if env_path:
+        p = Path(env_path)
+        return p if p.exists() else None
+
+    base = Path(__file__).parent.parent.parent
+    for candidate in ["eeg/eeglab", "eeglab"]:
+        p = base / candidate
+        if p.exists():
+            return p
+    return None
+
+
 @pytest.fixture(scope="session")
 def eeglab_path():
     """Path to EEGLAB installation."""
-    path = Path(__file__).parent.parent.parent / "eeglab"
-    if not path.exists():
-        pytest.skip("EEGLAB not found at ../eeglab")
+    path = _find_eeglab_path()
+    if path is None:
+        pytest.skip("EEGLAB not found")
     return path
 
 
@@ -28,24 +47,6 @@ def sample_data_path(eeglab_path):
 def tutorial_scripts_path(eeglab_path):
     """Path to EEGLAB tutorial scripts directory."""
     return eeglab_path / "tutorial_scripts"
-
-
-@pytest.fixture(scope="session")
-def eeg_data_file(sample_data_path):
-    """Path to continuous EEG data file."""
-    path = sample_data_path / "eeglab_data.set"
-    if not path.exists():
-        pytest.skip("eeglab_data.set not found")
-    return path
-
-
-@pytest.fixture(scope="session")
-def eeg_epochs_ica_file(sample_data_path):
-    """Path to epoched EEG data with ICA."""
-    path = sample_data_path / "eeglab_data_epochs_ica.set"
-    if not path.exists():
-        pytest.skip("eeglab_data_epochs_ica.set not found")
-    return path
 
 
 @pytest.fixture(scope="session")
@@ -65,3 +66,75 @@ def matlab_engine():
 def async_engine(matlab_engine):
     """Provide the engine for async tests."""
     return matlab_engine
+
+
+@pytest.fixture(scope="session")
+def eeglab_loaded_engine(matlab_engine, eeglab_path, sample_data_path):
+    """Shared engine with EEGLAB initialised and continuous dataset loaded.
+
+    Loads eeglab_data.set (32ch, 128Hz continuous) into the EEG variable.
+    Session-scoped so EEGLAB init + data load happens only once.
+    """
+    import asyncio
+
+    data_file = sample_data_path / "eeglab_data.set"
+    if not data_file.exists():
+        pytest.skip("eeglab_data.set not found")
+
+    loop = asyncio.get_event_loop()
+
+    # Add EEGLAB to path and initialise (nogui)
+    init_code = f"addpath('{eeglab_path}'); eeglab nogui;"
+    result = loop.run_until_complete(matlab_engine.execute(init_code))
+    if result.error:
+        pytest.skip(f"EEGLAB init failed: {result.error}")
+
+    # Load continuous dataset
+    load_code = f"EEG = pop_loadset('{data_file}');"
+    result = loop.run_until_complete(matlab_engine.execute(load_code))
+    if result.error:
+        pytest.skip(f"Failed to load EEG data: {result.error}")
+
+    yield matlab_engine
+
+
+@pytest.fixture(scope="session")
+def eeglab_epochs_engine(eeglab_loaded_engine, sample_data_path):
+    """Shared engine with epoched+ICA dataset loaded into EEG_epochs.
+
+    Loads eeglab_data_epochs_ica.set into EEG_epochs variable.
+    The continuous EEG variable from eeglab_loaded_engine remains available.
+    """
+    import asyncio
+
+    epochs_file = sample_data_path / "eeglab_data_epochs_ica.set"
+    if not epochs_file.exists():
+        pytest.skip("eeglab_data_epochs_ica.set not found")
+
+    loop = asyncio.get_event_loop()
+    load_code = f"EEG_epochs = pop_loadset('{epochs_file}');"
+    result = loop.run_until_complete(eeglab_loaded_engine.execute(load_code))
+    if result.error:
+        pytest.skip(f"Failed to load epochs data: {result.error}")
+
+    yield eeglab_loaded_engine
+
+
+@pytest.fixture
+def fresh_continuous_eeg(eeglab_loaded_engine, sample_data_path):
+    """Reload continuous EEG dataset to ensure known state.
+
+    Use this fixture for tests that need exact values from the continuous dataset
+    and may run after tests that modify the EEG variable.
+    """
+    import asyncio
+
+    data_file = sample_data_path / "eeglab_data.set"
+    load_code = f"EEG = pop_loadset('{data_file}');"
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(
+        eeglab_loaded_engine.execute(load_code, capture_plots=False)
+    )
+    if result.error:
+        pytest.skip(f"Failed to reload EEG data: {result.error}")
+    return eeglab_loaded_engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,16 @@ def _find_eeglab_path():
     """Resolve EEGLAB installation path.
 
     Check order: EEGLAB_PATH env var, ../eeg/eeglab, ../eeglab (legacy).
+    Raises FileNotFoundError if EEGLAB_PATH is set but invalid.
     """
     env_path = os.environ.get("EEGLAB_PATH")
     if env_path:
         p = Path(env_path)
-        return p if p.exists() else None
+        if not p.exists():
+            raise FileNotFoundError(
+                f"EEGLAB_PATH set to '{env_path}' but path does not exist"
+            )
+        return p
 
     base = Path(__file__).parent.parent.parent
     for candidate in ["eeg/eeglab", "eeglab"]:
@@ -40,13 +45,19 @@ def eeglab_path():
 @pytest.fixture(scope="session")
 def sample_data_path(eeglab_path):
     """Path to EEGLAB sample data directory."""
-    return eeglab_path / "sample_data"
+    path = eeglab_path / "sample_data"
+    if not path.exists():
+        pytest.skip(f"EEGLAB sample_data not found at {path}")
+    return path
 
 
 @pytest.fixture(scope="session")
 def tutorial_scripts_path(eeglab_path):
     """Path to EEGLAB tutorial scripts directory."""
-    return eeglab_path / "tutorial_scripts"
+    path = eeglab_path / "tutorial_scripts"
+    if not path.exists():
+        pytest.skip(f"EEGLAB tutorial_scripts not found at {path}")
+    return path
 
 
 @pytest.fixture(scope="session")
@@ -74,6 +85,10 @@ def eeglab_loaded_engine(matlab_engine, eeglab_path, sample_data_path):
 
     Loads eeglab_data.set (32ch, 128Hz continuous) into the EEG variable.
     Session-scoped so EEGLAB init + data load happens only once.
+
+    NOTE: Tests that execute MATLAB code may modify the EEG variable (e.g.,
+    epoching, resampling). Tests needing exact continuous-data values should
+    use the ``fresh_continuous_eeg`` fixture instead.
     """
     import asyncio
 

--- a/tests/test_figures_eeglab.py
+++ b/tests/test_figures_eeglab.py
@@ -1,0 +1,133 @@
+"""Test figure analysis tools with real EEGLAB plots.
+
+NO MOCKS - All tests use real MATLAB/EEGLAB data via shared session engine.
+Uses the epoched+ICA dataset for richer plot capabilities.
+"""
+
+import pytest
+
+from matlab_mcp.figure_analysis import FigureMetadata, PlotData
+from matlab_mcp.lint import run_lint
+
+
+class TestFigureMetadataExtraction:
+    """Test get_figure_metadata and get_plot_data with EEGLAB plots."""
+
+    @pytest.mark.asyncio
+    async def test_topoplot_metadata(self, eeglab_epochs_engine):
+        """Generate topoplot and verify figure metadata extraction."""
+        # Close any existing figures, then generate ERP topoplot
+        code = (
+            "close all; "
+            "pop_topoplot(EEG_epochs, 1, [100 200 300], "
+            "'ERP Topoplots', [1 3]);"
+        )
+        result = await eeglab_epochs_engine.execute(code, capture_plots=False)
+        assert result.error is None, f"Topoplot generation error: {result.error}"
+
+        metadata = await eeglab_epochs_engine.get_figure_metadata(figure_number=1)
+        assert isinstance(metadata, FigureMetadata)
+        assert metadata.figure_number == 1
+        # Topoplot should have subplots (one per time point)
+        assert metadata.num_subplots >= 1
+
+    @pytest.mark.asyncio
+    async def test_erpimage_metadata(self, eeglab_epochs_engine):
+        """Generate ERP image and verify metadata extraction."""
+        code = "close all; pop_erpimage(EEG_epochs, 1, 14, [], 'Cz', 10, 1, {});"
+        result = await eeglab_epochs_engine.execute(code, capture_plots=False)
+        assert result.error is None, f"ERP image error: {result.error}"
+
+        metadata = await eeglab_epochs_engine.get_figure_metadata(figure_number=1)
+        assert isinstance(metadata, FigureMetadata)
+        assert metadata.figure_number == 1
+
+    @pytest.mark.asyncio
+    async def test_simple_plot_data(self, eeglab_epochs_engine):
+        """Generate a simple ERP plot and extract plot data."""
+        # Plot the ERP at channel 14 (Cz)
+        code = (
+            "close all; "
+            "figure; "
+            "plot(EEG_epochs.times, mean(EEG_epochs.data(14,:,:), 3)); "
+            "xlabel('Time (ms)'); ylabel('Amplitude (uV)'); "
+            "title('ERP at Cz');"
+        )
+        result = await eeglab_epochs_engine.execute(code, capture_plots=False)
+        assert result.error is None, f"Plot generation error: {result.error}"
+
+        plot_data = await eeglab_epochs_engine.get_plot_data(
+            figure_number=1, line_index=1
+        )
+        assert isinstance(plot_data, PlotData)
+        assert plot_data.line_index == 1
+        assert len(plot_data.xdata) > 0
+        assert len(plot_data.ydata) > 0
+        assert len(plot_data.xdata) == len(plot_data.ydata)
+
+    @pytest.mark.asyncio
+    async def test_simple_plot_metadata(self, eeglab_epochs_engine):
+        """Verify metadata for a simple labeled plot."""
+        # Reuse the figure from previous test or create fresh
+        code = (
+            "close all; "
+            "figure; "
+            "plot(EEG_epochs.times, mean(EEG_epochs.data(14,:,:), 3)); "
+            "xlabel('Time (ms)'); ylabel('Amplitude (uV)'); "
+            "title('ERP at Cz');"
+        )
+        result = await eeglab_epochs_engine.execute(code, capture_plots=False)
+        assert result.error is None
+
+        metadata = await eeglab_epochs_engine.get_figure_metadata(figure_number=1)
+        assert metadata.title == "ERP at Cz"
+        assert metadata.xlabel == "Time (ms)"
+        assert metadata.ylabel == "Amplitude (uV)"
+        assert metadata.num_lines >= 1
+
+
+class TestAnalyzeFigure:
+    """Test prepare_figure_for_analysis with EEGLAB plots."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_figure_returns_prompt_and_data(self, eeglab_epochs_engine):
+        """analyze_figure should return figure data and an analysis prompt."""
+        code = (
+            "close all; "
+            "figure; "
+            "plot(EEG_epochs.times, mean(EEG_epochs.data(14,:,:), 3)); "
+            "title('ERP for analysis');"
+        )
+        result = await eeglab_epochs_engine.execute(code, capture_plots=False)
+        assert result.error is None
+
+        analysis = await eeglab_epochs_engine.prepare_figure_for_analysis(
+            figure_number=1
+        )
+        assert "figure" in analysis
+        assert "prompt" in analysis
+        assert isinstance(analysis["prompt"], str)
+        assert len(analysis["prompt"]) > 0
+
+
+class TestLintOnEeglabCode:
+    """Test matlab_lint on real EEGLAB code."""
+
+    @pytest.mark.asyncio
+    async def test_lint_eeglab_tutorial_script(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Lint should handle EEGLAB tutorial script without crashing."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        summary = await run_lint(eeglab_loaded_engine, script)
+        # Should return a valid summary (may or may not have issues)
+        assert hasattr(summary, "results")
+        assert isinstance(summary.results, list)
+
+    @pytest.mark.asyncio
+    async def test_lint_inline_eeglab_code(self, eeglab_loaded_engine):
+        """Lint inline EEGLAB code snippet."""
+        code = "EEG = pop_loadset('test.set');\ndata = EEG.data;"
+        summary = await run_lint(eeglab_loaded_engine, code)
+        assert hasattr(summary, "results")
+        assert isinstance(summary.results, list)

--- a/tests/test_figures_eeglab.py
+++ b/tests/test_figures_eeglab.py
@@ -1,7 +1,7 @@
 """Test figure analysis tools with real EEGLAB plots.
 
 NO MOCKS - All tests use real MATLAB/EEGLAB data via shared session engine.
-Uses the epoched+ICA dataset for richer plot capabilities.
+Figure/plot tests use the epoched+ICA dataset; lint tests use the continuous dataset.
 """
 
 import pytest
@@ -68,7 +68,6 @@ class TestFigureMetadataExtraction:
     @pytest.mark.asyncio
     async def test_simple_plot_metadata(self, eeglab_epochs_engine):
         """Verify metadata for a simple labeled plot."""
-        # Reuse the figure from previous test or create fresh
         code = (
             "close all; "
             "figure; "

--- a/tests/test_integration_eeglab.py
+++ b/tests/test_integration_eeglab.py
@@ -19,74 +19,74 @@ class TestFullPipeline:
     ):
         """Execute a multi-step EEG pipeline and verify workspace at each stage."""
         engine = eeglab_loaded_engine
-
-        # Stage 1: Reload fresh continuous data (other tests may have modified EEG)
         reload_code = f"EEG = pop_loadset('{sample_data_path / 'eeglab_data.set'}');"
-        result = await engine.execute(reload_code, capture_plots=False)
-        assert result.error is None, f"Reload error: {result.error}"
 
-        eeg_info = await engine.get_variable(
-            "EEG", fields=["nbchan", "srate", "pnts", "trials"]
-        )
-        assert eeg_info["nbchan"] == 32
-        assert eeg_info["srate"] == 128
-        assert eeg_info["trials"] == 1  # continuous
+        try:
+            # Stage 1: Reload fresh continuous data (other tests may have modified EEG)
+            result = await engine.execute(reload_code, capture_plots=False)
+            assert result.error is None, f"Reload error: {result.error}"
 
-        # Stage 2: High-pass filter at 1 Hz
-        filter_code = "EEG = pop_eegfilt(EEG, 1, 0, [], [0]);"
-        result = await engine.execute(filter_code, capture_plots=False)
-        assert result.error is None, f"Filter error: {result.error}"
+            eeg_info = await engine.get_variable(
+                "EEG", fields=["nbchan", "srate", "pnts", "trials"]
+            )
+            assert eeg_info["nbchan"] == 32
+            assert eeg_info["srate"] == 128
+            assert eeg_info["trials"] == 1  # continuous
 
-        # Verify: same dimensions, still continuous
-        post_filter = await engine.get_variable(
-            "EEG", fields=["nbchan", "pnts", "trials"]
-        )
-        assert post_filter["nbchan"] == 32
-        assert post_filter["trials"] == 1
+            # Stage 2: High-pass filter at 1 Hz
+            filter_code = "EEG = pop_eegfilt(EEG, 1, 0, [], [0]);"
+            result = await engine.execute(filter_code, capture_plots=False)
+            assert result.error is None, f"Filter error: {result.error}"
 
-        # Stage 3: Epoch around 'square' events
-        epoch_code = (
-            "EEG = pop_epoch(EEG, {'square'}, [-1 2], "
-            "'newname', 'Epochs', 'epochinfo', 'yes');"
-        )
-        result = await engine.execute(epoch_code, capture_plots=False)
-        assert result.error is None, f"Epoch error: {result.error}"
+            # Verify: same dimensions, still continuous
+            post_filter = await engine.get_variable(
+                "EEG", fields=["nbchan", "pnts", "trials"]
+            )
+            assert post_filter["nbchan"] == 32
+            assert post_filter["trials"] == 1
 
-        post_epoch = await engine.get_variable(
-            "EEG", fields=["nbchan", "trials", "pnts"]
-        )
-        assert post_epoch["nbchan"] == 32
-        assert post_epoch["trials"] > 1, "Should have multiple epochs"
-        # 3 seconds at 128 Hz = 384 points
-        assert post_epoch["pnts"] == 384
+            # Stage 3: Epoch around 'square' events
+            epoch_code = (
+                "EEG = pop_epoch(EEG, {'square'}, [-1 2], "
+                "'newname', 'Epochs', 'epochinfo', 'yes');"
+            )
+            result = await engine.execute(epoch_code, capture_plots=False)
+            assert result.error is None, f"Epoch error: {result.error}"
 
-        # Stage 4: Remove baseline
-        baseline_code = "EEG = pop_rmbase(EEG, [-1000 0]);"
-        result = await engine.execute(baseline_code, capture_plots=False)
-        assert result.error is None, f"Baseline error: {result.error}"
+            post_epoch = await engine.get_variable(
+                "EEG", fields=["nbchan", "trials", "pnts"]
+            )
+            assert post_epoch["nbchan"] == 32
+            assert post_epoch["trials"] > 1, "Should have multiple epochs"
+            # 3 seconds at 128 Hz = 384 points
+            assert post_epoch["pnts"] == 384
 
-        # Stage 5: Generate a plot and verify figure metadata
-        plot_code = (
-            "close all; figure; "
-            "plot(EEG.times, mean(EEG.data(14,:,:), 3)); "
-            "xlabel('Time (ms)'); ylabel('uV'); title('ERP at Cz');"
-        )
-        result = await engine.execute(plot_code, capture_plots=False)
-        assert result.error is None, f"Plot error: {result.error}"
+            # Stage 4: Remove baseline
+            baseline_code = "EEG = pop_rmbase(EEG, [-1000 0]);"
+            result = await engine.execute(baseline_code, capture_plots=False)
+            assert result.error is None, f"Baseline error: {result.error}"
 
-        metadata = await engine.get_figure_metadata(figure_number=1)
-        assert metadata.title == "ERP at Cz"
-        assert metadata.num_lines >= 1
+            # Stage 5: Generate a plot and verify figure metadata
+            plot_code = (
+                "close all; figure; "
+                "plot(EEG.times, mean(EEG.data(14,:,:), 3)); "
+                "xlabel('Time (ms)'); ylabel('uV'); title('ERP at Cz');"
+            )
+            result = await engine.execute(plot_code, capture_plots=False)
+            assert result.error is None, f"Plot error: {result.error}"
 
-        # Stage 6: Verify workspace listing shows expected variables
-        variables = await engine.list_workspace_variables()
-        var_names = [v["name"] for v in variables]
-        assert "EEG" in var_names
+            metadata = await engine.get_figure_metadata(figure_number=1)
+            assert metadata.title == "ERP at Cz"
+            assert metadata.num_lines >= 1
 
-        # Reload continuous data to restore state for other tests
-        reload_code = f"EEG = pop_loadset('{sample_data_path / 'eeglab_data.set'}');"
-        result = await engine.execute(reload_code, capture_plots=False)
-        assert result.error is None
+            # Stage 6: Verify workspace listing shows expected variables
+            variables = await engine.list_workspace_variables()
+            var_names = [v["name"] for v in variables]
+            assert "EEG" in var_names
+
+        finally:
+            # Reload continuous data to restore state for other tests
+            await engine.execute(reload_code, capture_plots=False)
 
 
 class TestScriptedPipeline:
@@ -177,6 +177,10 @@ class TestErrorRecovery:
             "this_function_does_not_exist(42);", capture_plots=False
         )
         assert result.error is not None
+        assert (
+            "ndefined function" in result.error
+            or "nrecognized function" in result.error
+        ), f"Expected undefined function error, got: {result.error}"
 
         # EEG should still be accessible
         post = await engine.get_variable("EEG", fields=["nbchan", "srate"])
@@ -188,8 +192,9 @@ class TestErrorRecovery:
         """Should be able to continue normal operations after an error."""
         engine = eeglab_loaded_engine
 
-        # Trigger an error
-        await engine.execute("nonexistent_func();", capture_plots=False)
+        # Trigger an error and verify it actually occurred
+        error_result = await engine.execute("nonexistent_func();", capture_plots=False)
+        assert error_result.error is not None, "Expected error was not triggered"
 
         # Should still be able to run valid code
         result = await engine.execute("x_test = 42;", capture_plots=False)

--- a/tests/test_integration_eeglab.py
+++ b/tests/test_integration_eeglab.py
@@ -1,0 +1,202 @@
+"""End-to-end integration tests with real EEGLAB pipeline.
+
+NO MOCKS - All tests use real MATLAB/EEGLAB data via shared session engine.
+Tests a full neuroscience workflow: load, filter, epoch, plot, inspect.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestFullPipeline:
+    """Test a complete EEG processing pipeline through MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_pipeline_load_filter_epoch_plot(
+        self, eeglab_loaded_engine, sample_data_path
+    ):
+        """Execute a multi-step EEG pipeline and verify workspace at each stage."""
+        engine = eeglab_loaded_engine
+
+        # Stage 1: Reload fresh continuous data (other tests may have modified EEG)
+        reload_code = f"EEG = pop_loadset('{sample_data_path / 'eeglab_data.set'}');"
+        result = await engine.execute(reload_code, capture_plots=False)
+        assert result.error is None, f"Reload error: {result.error}"
+
+        eeg_info = await engine.get_variable(
+            "EEG", fields=["nbchan", "srate", "pnts", "trials"]
+        )
+        assert eeg_info["nbchan"] == 32
+        assert eeg_info["srate"] == 128
+        assert eeg_info["trials"] == 1  # continuous
+
+        # Stage 2: High-pass filter at 1 Hz
+        filter_code = "EEG = pop_eegfilt(EEG, 1, 0, [], [0]);"
+        result = await engine.execute(filter_code, capture_plots=False)
+        assert result.error is None, f"Filter error: {result.error}"
+
+        # Verify: same dimensions, still continuous
+        post_filter = await engine.get_variable(
+            "EEG", fields=["nbchan", "pnts", "trials"]
+        )
+        assert post_filter["nbchan"] == 32
+        assert post_filter["trials"] == 1
+
+        # Stage 3: Epoch around 'square' events
+        epoch_code = (
+            "EEG = pop_epoch(EEG, {'square'}, [-1 2], "
+            "'newname', 'Epochs', 'epochinfo', 'yes');"
+        )
+        result = await engine.execute(epoch_code, capture_plots=False)
+        assert result.error is None, f"Epoch error: {result.error}"
+
+        post_epoch = await engine.get_variable(
+            "EEG", fields=["nbchan", "trials", "pnts"]
+        )
+        assert post_epoch["nbchan"] == 32
+        assert post_epoch["trials"] > 1, "Should have multiple epochs"
+        # 3 seconds at 128 Hz = 384 points
+        assert post_epoch["pnts"] == 384
+
+        # Stage 4: Remove baseline
+        baseline_code = "EEG = pop_rmbase(EEG, [-1000 0]);"
+        result = await engine.execute(baseline_code, capture_plots=False)
+        assert result.error is None, f"Baseline error: {result.error}"
+
+        # Stage 5: Generate a plot and verify figure metadata
+        plot_code = (
+            "close all; figure; "
+            "plot(EEG.times, mean(EEG.data(14,:,:), 3)); "
+            "xlabel('Time (ms)'); ylabel('uV'); title('ERP at Cz');"
+        )
+        result = await engine.execute(plot_code, capture_plots=False)
+        assert result.error is None, f"Plot error: {result.error}"
+
+        metadata = await engine.get_figure_metadata(figure_number=1)
+        assert metadata.title == "ERP at Cz"
+        assert metadata.num_lines >= 1
+
+        # Stage 6: Verify workspace listing shows expected variables
+        variables = await engine.list_workspace_variables()
+        var_names = [v["name"] for v in variables]
+        assert "EEG" in var_names
+
+        # Reload continuous data to restore state for other tests
+        reload_code = f"EEG = pop_loadset('{sample_data_path / 'eeglab_data.set'}');"
+        result = await engine.execute(reload_code, capture_plots=False)
+        assert result.error is None
+
+
+class TestScriptedPipeline:
+    """Test pipeline via script creation and section execution."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_execute_pipeline_script(
+        self, eeglab_loaded_engine, sample_data_path
+    ):
+        """Create a multi-section script, execute sections, verify workspace."""
+        engine = eeglab_loaded_engine
+
+        # Create a temporary MATLAB script with sections
+        script_content = f"""\
+%% Load Data
+EEG_pipe = pop_loadset('{sample_data_path / "eeglab_data.set"}');
+
+%% Filter Data
+EEG_pipe = pop_eegfilt(EEG_pipe, 1, 0, [], [0]);
+
+%% Inspect Data
+pipe_info.nbchan = EEG_pipe.nbchan;
+pipe_info.srate = EEG_pipe.srate;
+pipe_info.pnts = EEG_pipe.pnts;
+"""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".m", delete=False, dir="/tmp"
+        ) as f:
+            f.write(script_content)
+            script_path = f.name
+
+        try:
+            # Verify sections are parsed
+            sections = await engine.get_script_sections(script_path)
+            assert len(sections) == 3
+            titles = [s["title"] for s in sections]
+            assert "Load Data" in titles
+            assert "Filter Data" in titles
+            assert "Inspect Data" in titles
+
+            # Execute section 0: Load
+            result = await engine.execute_section_by_index(
+                script_path, section_index=0, capture_plots=False
+            )
+            assert result.error is None, f"Load section error: {result.error}"
+
+            # Verify EEG_pipe exists
+            pipe_info = await engine.get_variable(
+                "EEG_pipe", fields=["nbchan", "srate"]
+            )
+            assert pipe_info["nbchan"] == 32
+
+            # Execute section 1: Filter
+            result = await engine.execute_section_by_index(
+                script_path, section_index=1, capture_plots=False
+            )
+            assert result.error is None, f"Filter section error: {result.error}"
+
+            # Execute section 2: Inspect
+            result = await engine.execute_section_by_index(
+                script_path, section_index=2, capture_plots=False
+            )
+            assert result.error is None, f"Inspect section error: {result.error}"
+
+            # Verify pipe_info struct was created
+            info = await engine.get_variable("pipe_info")
+            assert info["nbchan"] == 32
+            assert info["srate"] == 128
+
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+
+class TestErrorRecovery:
+    """Test that workspace is preserved after errors."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_survives_error(self, eeglab_loaded_engine):
+        """After executing bad code, workspace should still be intact."""
+        engine = eeglab_loaded_engine
+
+        # Verify EEG exists before the error
+        pre = await engine.get_variable("EEG", fields=["nbchan"])
+        assert pre["nbchan"] == 32
+
+        # Execute code that will error
+        result = await engine.execute(
+            "this_function_does_not_exist(42);", capture_plots=False
+        )
+        assert result.error is not None
+
+        # EEG should still be accessible
+        post = await engine.get_variable("EEG", fields=["nbchan", "srate"])
+        assert post["nbchan"] == 32
+        assert post["srate"] == 128
+
+    @pytest.mark.asyncio
+    async def test_continue_pipeline_after_error(self, eeglab_loaded_engine):
+        """Should be able to continue normal operations after an error."""
+        engine = eeglab_loaded_engine
+
+        # Trigger an error
+        await engine.execute("nonexistent_func();", capture_plots=False)
+
+        # Should still be able to run valid code
+        result = await engine.execute("x_test = 42;", capture_plots=False)
+        assert result.error is None
+
+        val = await engine.get_variable("x_test")
+        assert val == 42 or (isinstance(val, dict) and val.get("x_test") == 42)
+
+        # Clean up
+        await engine.execute("clear x_test;", capture_plots=False)

--- a/tests/test_sections_eeglab.py
+++ b/tests/test_sections_eeglab.py
@@ -1,0 +1,142 @@
+"""Test section execution tools with real EEGLAB tutorial scripts.
+
+NO MOCKS - All tests use real MATLAB/EEGLAB data via shared session engine.
+"""
+
+import pytest
+
+
+class TestGetScriptSections:
+    """Test get_script_sections on EEGLAB tutorial scripts."""
+
+    @pytest.mark.asyncio
+    async def test_eeglab_history_has_sections(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """eeglab_history.m should have multiple sections with titles."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        sections = await eeglab_loaded_engine.get_script_sections(script)
+        assert len(sections) >= 2, "Expected at least 2 sections"
+        for sec in sections:
+            assert "index" in sec
+            assert "title" in sec
+            assert "start_line" in sec
+            assert "end_line" in sec
+
+    @pytest.mark.asyncio
+    async def test_section_titles_present(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Sections should have meaningful titles from %% comments."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        sections = await eeglab_loaded_engine.get_script_sections(script)
+        titles = [s["title"] for s in sections]
+        # First section should be about getting started
+        assert any("started" in t.lower() or "history" in t.lower() for t in titles)
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file_error(self, eeglab_loaded_engine):
+        """get_script_sections on a missing file should raise or return error."""
+        with pytest.raises(FileNotFoundError):
+            await eeglab_loaded_engine.get_script_sections("/tmp/no_such_file.m")
+
+
+class TestExecuteSectionByIndex:
+    """Test execute_section_by_index with EEGLAB scripts."""
+
+    @pytest.mark.asyncio
+    async def test_execute_first_section(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Executing the first section should succeed without error."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        result = await eeglab_loaded_engine.execute_section_by_index(
+            script, section_index=0, capture_plots=False
+        )
+        assert result.error is None, f"Section execution error: {result.error}"
+
+    @pytest.mark.asyncio
+    async def test_invalid_section_index(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Executing with an out-of-range index should raise IndexError."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        with pytest.raises(IndexError):
+            await eeglab_loaded_engine.execute_section_by_index(
+                script, section_index=999, capture_plots=False
+            )
+
+
+class TestExecuteSectionByTitle:
+    """Test execute_section_by_title with partial title matching."""
+
+    @pytest.mark.asyncio
+    async def test_partial_title_match(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Should match a section by partial, case-insensitive title."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        # "Reduce sampling rate" is a known section title
+        result = await eeglab_loaded_engine.execute_section_by_title(
+            script, section_title="reduce sampling", capture_plots=False
+        )
+        assert result.error is None, f"Section execution error: {result.error}"
+
+    @pytest.mark.asyncio
+    async def test_no_matching_title(self, eeglab_loaded_engine, tutorial_scripts_path):
+        """A title that matches nothing should raise ValueError."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        with pytest.raises(ValueError):
+            await eeglab_loaded_engine.execute_section_by_title(
+                script, section_title="xyzzy_nonexistent_title", capture_plots=False
+            )
+
+
+class TestSequentialSectionExecution:
+    """Test that workspace state persists across sequential section executions."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_preserved_between_sections(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Variables created in one section should be available in subsequent ones."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+
+        # Execute first section (loads data, creates EEG variable)
+        result = await eeglab_loaded_engine.execute_section_by_index(
+            script, section_index=0, capture_plots=False
+        )
+        assert result.error is None, f"Section 0 error: {result.error}"
+
+        # EEG should exist in workspace
+        variables = await eeglab_loaded_engine.list_workspace_variables(pattern="^EEG$")
+        names = [v["name"] for v in variables]
+        assert "EEG" in names, "EEG not found after executing first section"
+
+        # Execute second section (resampling) -- uses EEG from first section
+        result = await eeglab_loaded_engine.execute_section_by_index(
+            script, section_index=1, capture_plots=False
+        )
+        assert result.error is None, f"Section 1 error: {result.error}"
+
+
+class TestExecuteSection:
+    """Test execute_section with explicit line ranges."""
+
+    @pytest.mark.asyncio
+    async def test_line_range_execution(
+        self, eeglab_loaded_engine, tutorial_scripts_path
+    ):
+        """Executing a specific line range should work."""
+        script = str(tutorial_scripts_path / "eeglab_history.m")
+        sections = await eeglab_loaded_engine.get_script_sections(script)
+        assert len(sections) > 0
+
+        # Use the line range from the first section
+        sec = sections[0]
+        result = await eeglab_loaded_engine.execute_section(
+            script,
+            section_range=(sec["start_line"], sec["end_line"]),
+            capture_plots=False,
+        )
+        assert result.error is None, f"Line range execution error: {result.error}"

--- a/tests/test_workspace_eeglab.py
+++ b/tests/test_workspace_eeglab.py
@@ -1,387 +1,181 @@
-#!/usr/bin/env python3
+"""Test workspace retrieval tools with real EEGLAB data.
+
+NO MOCKS - All tests use real MATLAB/EEGLAB data via shared session engine.
 """
-Test selective workspace retrieval with real EEGLAB data.
-
-These tests verify that the new workspace tools (get_variable, get_struct_info,
-list_workspace_variables) work correctly with complex EEGLAB structures.
-
-NO MOCKS - All tests use real MATLAB/EEGLAB data.
-"""
-
-import asyncio
-import json
-import sys
-from pathlib import Path
 
 import pytest
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from matlab_mcp.engine import MatlabEngine
-
-
-class TestSelectiveVariableRetrieval:
-    """Test get_variable with EEGLAB data."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self, eeglab_path, eeg_data_file):
-        """Set up test with EEGLAB data loaded."""
-        self.eeglab_path = eeglab_path
-        self.eeg_data_file = eeg_data_file
-        self.engine = MatlabEngine()
-
-    async def _load_eeg_data(self):
-        """Load EEG data into MATLAB workspace."""
-        await self.engine.initialize()
-
-        # Add EEGLAB to path
-        eeglab_code = f"""
-        addpath('{self.eeglab_path}');
-        eeglab nogui;
-        """
-        await self.engine.execute(eeglab_code)
-
-        # Load sample data
-        load_code = f"EEG = pop_loadset('{self.eeg_data_file}');"
-        result = await self.engine.execute(load_code)
-        assert result.error is None, f"Failed to load EEG: {result.error}"
+class TestGetVariable:
+    """Test get_variable with EEGLAB continuous dataset."""
 
     @pytest.mark.asyncio
-    async def test_get_scalar_fields_only(self):
-        """Test retrieving only scalar fields from EEG struct."""
-        await self._load_eeg_data()
-
-        # Get only scalar fields
-        result = await self.engine.get_variable(
-            "EEG", fields=["nbchan", "srate", "pnts", "trials"], max_elements=100
+    async def test_scalar_fields_exact_values(self, fresh_continuous_eeg):
+        """Scalar fields should return exact known values for continuous data."""
+        result = await fresh_continuous_eeg.get_variable(
+            "EEG", fields=["nbchan", "srate", "pnts", "trials"]
         )
+        assert result["nbchan"] == 32
+        assert result["srate"] == 128
+        assert result["pnts"] == 30504
+        assert result["trials"] == 1  # continuous = 1 trial
 
-        # Should have the requested fields
-        assert "nbchan" in result
-        assert "srate" in result
-        assert "pnts" in result
-
-        # Values should be scalars (or small arrays)
-        assert isinstance(result["nbchan"], (int, float, list))
-        assert isinstance(result["srate"], (int, float, list))
-
-        # Should NOT have the huge data field
+    @pytest.mark.asyncio
+    async def test_scalar_fields_exclude_data(self, eeglab_loaded_engine):
+        """Requesting scalar fields should not return the huge data array."""
+        result = await eeglab_loaded_engine.get_variable(
+            "EEG", fields=["nbchan", "srate"]
+        )
         assert "data" not in result
 
-        print(f"Scalar fields: {json.dumps(result, indent=2, default=str)}")
+    @pytest.mark.asyncio
+    async def test_depth_zero_returns_struct_info(self, eeglab_loaded_engine):
+        """depth=0 should return struct metadata, not actual values."""
+        result = await eeglab_loaded_engine.get_variable("EEG", depth=0)
+        assert isinstance(result, dict)
+        # Should indicate it's a struct with type info
+        assert "_mcp_type" in result or "fields" in result or len(result) > 5
 
     @pytest.mark.asyncio
-    async def test_get_struct_info_without_values(self):
-        """Test get_struct_info returns field info without transferring data."""
-        await self._load_eeg_data()
-
-        # Get struct info
-        info = await self.engine.get_struct_info("EEG")
-
-        # Should have field information
-        assert "data" in info or "_mcp_error" not in info
-        assert "nbchan" in info or len(info) > 0
-
-        # Check that we got metadata, not actual data
-        if "data" in info:
-            data_info = info["data"]
-            # Should have size info (using var_size/var_numel to avoid MATLAB reserved names)
-            assert (
-                "var_size" in data_info
-                or "var_numel" in data_info
-                or "bytes" in data_info
-            )
-            # Should NOT have actual array values
-            assert not isinstance(data_info, list)
-
-        print(f"Struct info: {json.dumps(info, indent=2, default=str)}")
-
-    @pytest.mark.asyncio
-    async def test_depth_control(self):
-        """Test that depth=0 returns only field names."""
-        await self._load_eeg_data()
-
-        # Depth 0 should return info only
-        result = await self.engine.get_variable("EEG", depth=0)
-
-        # Should indicate it's a struct with fields listed
-        assert "_mcp_type" in result or "fields" in result or isinstance(result, dict)
-
-        print(f"Depth 0 result: {json.dumps(result, indent=2, default=str)}")
-
-    @pytest.mark.asyncio
-    async def test_nested_struct_access(self):
-        """Test accessing nested struct fields like EEG.chanlocs."""
-        await self._load_eeg_data()
-
-        # Get chanlocs info
-        result = await self.engine.get_variable("EEG.chanlocs", depth=0)
-
-        # Should return info about chanlocs struct array
+    async def test_nested_struct_chanlocs(self, eeglab_loaded_engine):
+        """Accessing EEG.chanlocs should return struct array info."""
+        result = await eeglab_loaded_engine.get_variable("EEG.chanlocs", depth=0)
         assert result is not None
-        print(f"Chanlocs info: {json.dumps(result, indent=2, default=str)}")
+        assert isinstance(result, dict)
 
     @pytest.mark.asyncio
-    async def test_max_elements_limiting(self):
-        """Test that max_elements limits array transfer."""
-        await self._load_eeg_data()
-
-        # Get data with limited elements
-        result = await self.engine.get_variable("EEG.data", max_elements=50)
-
-        # Should be a summary, not full data
-        if isinstance(result, dict):
-            if "_mcp_type" in result:
-                assert result["_mcp_type"] in ["large_array", "medium_array"]
-                # Sample should be limited
-                if "sample" in result:
-                    assert len(result["sample"]) <= 50
-        else:
-            # If it returned full data, it should be small
-            if isinstance(result, list):
-                print(f"Returned list of length {len(result)}")
-
-        print(
-            f"Data with max_elements=50: {json.dumps(result, indent=2, default=str)[:500]}..."
-        )
+    async def test_data_max_elements_limits_transfer(self, eeglab_loaded_engine):
+        """EEG.data with max_elements=50 should limit what is transferred."""
+        result = await eeglab_loaded_engine.get_variable("EEG.data", max_elements=50)
+        # May return dict (summary) or truncated data (string/list)
+        if isinstance(result, dict) and "_mcp_type" in result:
+            assert result["_mcp_type"] in ["large_array", "medium_array"]
+            if "sample" in result:
+                assert len(result["sample"]) <= 50
+        # If it returns raw data, it should be limited in size
+        # (not the full 32x30504 array)
 
     @pytest.mark.asyncio
-    async def test_token_savings(self):
-        """Compare token usage between full workspace and selective retrieval."""
-        await self._load_eeg_data()
+    async def test_nonexistent_variable(self, eeglab_loaded_engine):
+        """Requesting a variable that does not exist should return error."""
+        result = await eeglab_loaded_engine.get_variable("totally_nonexistent_xyz")
+        assert "_mcp_error" in result
+
+    @pytest.mark.asyncio
+    async def test_token_savings(self, eeglab_loaded_engine):
+        """Selective retrieval should use far fewer tokens than full workspace."""
+        import json
 
         def estimate_tokens(data):
             return len(json.dumps(data, default=str)) // 4
 
-        # Method 1: Full workspace (old way)
-        full_workspace = await self.engine.get_workspace()
-        full_tokens = estimate_tokens(full_workspace)
-
-        # Method 2: Selective retrieval (new way)
-        selective = await self.engine.get_variable(
+        full = await eeglab_loaded_engine.get_workspace()
+        selective = await eeglab_loaded_engine.get_variable(
             "EEG", fields=["nbchan", "srate", "pnts", "xmin", "xmax"]
         )
-        selective_tokens = estimate_tokens(selective)
+        assert estimate_tokens(selective) < estimate_tokens(full)
 
-        print(f"Full workspace tokens: {full_tokens:,}")
-        print(f"Selective retrieval tokens: {selective_tokens:,}")
-        print(f"Token savings: {(1 - selective_tokens / full_tokens) * 100:.1f}%")
 
-        # Selective should be significantly smaller
-        assert selective_tokens < full_tokens
+class TestGetStructInfo:
+    """Test get_struct_info with EEGLAB structures."""
 
-    def teardown_method(self, method):
-        """Clean up after each test."""
-        if hasattr(self, "engine") and self.engine.eng is not None:
-            self.engine.close()
+    @pytest.mark.asyncio
+    async def test_eeg_struct_has_expected_fields(self, eeglab_loaded_engine):
+        """EEG struct should contain core fields with type metadata."""
+        info = await eeglab_loaded_engine.get_struct_info("EEG")
+        for field in ["data", "chanlocs", "event", "nbchan", "srate", "pnts"]:
+            assert field in info, f"Missing expected field: {field}"
+
+    @pytest.mark.asyncio
+    async def test_eeg_field_class_types(self, eeglab_loaded_engine):
+        """Fields should report correct MATLAB class types."""
+        info = await eeglab_loaded_engine.get_struct_info("EEG")
+        # data should be a numeric (single or double)
+        if isinstance(info.get("data"), dict) and "class" in info["data"]:
+            assert info["data"]["class"] in ("single", "double")
+        # chanlocs should be a struct
+        if isinstance(info.get("chanlocs"), dict) and "is_struct" in info["chanlocs"]:
+            assert info["chanlocs"]["is_struct"] is True
+
+    @pytest.mark.asyncio
+    async def test_chanlocs_fields(self, eeglab_loaded_engine):
+        """EEG.chanlocs should have standard channel location fields."""
+        info = await eeglab_loaded_engine.get_struct_info("EEG.chanlocs")
+        expected = {"labels", "theta", "radius", "X", "Y", "Z"}
+        found = set(info.keys())
+        # At least most of the expected fields should be present
+        overlap = expected & found
+        assert len(overlap) >= 4, f"Only found {overlap} of {expected}"
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_variable_error(self, eeglab_loaded_engine):
+        """get_struct_info on nonexistent variable should return error."""
+        info = await eeglab_loaded_engine.get_struct_info("nonexistent_var_xyz")
+        assert "_mcp_error" in info
 
 
 class TestListWorkspaceVariables:
-    """Test list_workspace_variables with filtering."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self, eeglab_path, eeg_data_file):
-        """Set up test with EEGLAB."""
-        self.eeglab_path = eeglab_path
-        self.eeg_data_file = eeg_data_file
-        self.engine = MatlabEngine()
-
-    async def _setup_workspace(self):
-        """Create multiple variables in workspace."""
-        await self.engine.initialize()
-
-        # Add EEGLAB to path
-        eeglab_code = f"""
-        addpath('{self.eeglab_path}');
-        eeglab nogui;
-        """
-        await self.engine.execute(eeglab_code)
-
-        # Load EEG and create some additional variables
-        setup_code = f"""
-        EEG = pop_loadset('{self.eeg_data_file}');
-        EEG_backup = EEG;
-        data_matrix = rand(100, 100);
-        event_types = {{'stimulus', 'response', 'feedback'}};
-        sample_rate = 128;
-        """
-        result = await self.engine.execute(setup_code)
-        assert result.error is None
+    """Test list_workspace_variables with EEGLAB workspace."""
 
     @pytest.mark.asyncio
-    async def test_list_all_variables(self):
-        """Test listing all variables without filter."""
-        await self._setup_workspace()
+    async def test_eeg_listed_as_struct(self, eeglab_loaded_engine):
+        """EEG should appear in workspace listing as a struct."""
+        variables = await eeglab_loaded_engine.list_workspace_variables()
+        names = [v["name"] for v in variables]
+        assert "EEG" in names
+        eeg_entry = next(v for v in variables if v["name"] == "EEG")
+        assert eeg_entry["class"] == "struct"
 
-        variables = await self.engine.list_workspace_variables()
-
-        # Should have multiple variables
+    @pytest.mark.asyncio
+    async def test_variable_entry_structure(self, eeglab_loaded_engine):
+        """Each variable entry should have name, class, size, bytes."""
+        variables = await eeglab_loaded_engine.list_workspace_variables()
         assert len(variables) > 0
-
-        # Check structure
         for var in variables:
             assert "name" in var
             assert "class" in var
             assert "size" in var
             assert "bytes" in var
 
-        print(f"All variables: {json.dumps(variables, indent=2, default=str)}")
-
     @pytest.mark.asyncio
-    async def test_filter_by_pattern(self):
-        """Test filtering variables by name pattern."""
-        await self._setup_workspace()
-
-        # Filter for EEG* variables
-        eeg_vars = await self.engine.list_workspace_variables(pattern="^EEG")
-
-        # Should find EEG and EEG_backup
+    async def test_filter_by_pattern(self, eeglab_loaded_engine):
+        """Pattern filter should match variable names."""
+        eeg_vars = await eeglab_loaded_engine.list_workspace_variables(pattern="^EEG")
         names = [v["name"] for v in eeg_vars]
-        assert "EEG" in names or len(eeg_vars) > 0
-
-        print(f"EEG* variables: {names}")
+        assert "EEG" in names
+        # All returned names should start with EEG
+        for name in names:
+            assert name.startswith("EEG"), f"{name} does not match ^EEG"
 
     @pytest.mark.asyncio
-    async def test_filter_by_type(self):
-        """Test filtering variables by type."""
-        await self._setup_workspace()
-
-        # Filter for struct variables only
-        struct_vars = await self.engine.list_workspace_variables(var_type="struct")
-
-        # All should be structs
+    async def test_filter_by_struct_type(self, eeglab_loaded_engine):
+        """Type filter for struct should return only structs."""
+        struct_vars = await eeglab_loaded_engine.list_workspace_variables(
+            var_type="struct"
+        )
         for var in struct_vars:
             assert var["is_struct"] is True
 
-        print(f"Struct variables: {[v['name'] for v in struct_vars]}")
+
+class TestGetWorkspace:
+    """Test get_workspace with EEGLAB data."""
 
     @pytest.mark.asyncio
-    async def test_filter_by_pattern_and_type(self):
-        """Test filtering by both pattern and type."""
-        await self._setup_workspace()
-
-        # Filter for numeric variables with 'data' in name
-        data_vars = await self.engine.list_workspace_variables(
-            pattern="data", var_type="double"
-        )
-
-        print(f"Numeric 'data' variables: {[v['name'] for v in data_vars]}")
-
-    def teardown_method(self, method):
-        """Clean up after each test."""
-        if hasattr(self, "engine") and self.engine.eng is not None:
-            self.engine.close()
-
-
-class TestGetStructInfo:
-    """Test get_struct_info with complex EEGLAB structures."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self, eeglab_path, eeg_data_file):
-        """Set up test with EEGLAB."""
-        self.eeglab_path = eeglab_path
-        self.eeg_data_file = eeg_data_file
-        self.engine = MatlabEngine()
-
-    async def _load_eeg_data(self):
-        """Load EEG data into MATLAB workspace."""
-        await self.engine.initialize()
-
-        eeglab_code = f"""
-        addpath('{self.eeglab_path}');
-        eeglab nogui;
-        EEG = pop_loadset('{self.eeg_data_file}');
-        """
-        result = await self.engine.execute(eeglab_code)
-        assert result.error is None
+    async def test_workspace_contains_eeg(self, eeglab_loaded_engine):
+        """Full workspace should include EEG variable."""
+        ws = await eeglab_loaded_engine.get_workspace()
+        assert "EEG" in ws
 
     @pytest.mark.asyncio
-    async def test_get_eeg_struct_info(self):
-        """Test getting info for main EEG struct."""
-        await self._load_eeg_data()
-
-        info = await self.engine.get_struct_info("EEG")
-
-        # Should have main EEG fields
-        found_fields = list(info.keys())
-
-        print(f"EEG fields: {found_fields}")
-        print(f"Full info: {json.dumps(info, indent=2, default=str)[:2000]}...")
-
-        # At least some expected fields should be present
-        assert len(found_fields) > 0
-
-    @pytest.mark.asyncio
-    async def test_struct_field_types(self):
-        """Test that struct info includes type information."""
-        await self._load_eeg_data()
-
-        info = await self.engine.get_struct_info("EEG")
-
-        # Check that we have type info for fields
-        for field_name, field_info in info.items():
-            if isinstance(field_info, dict):
-                # Should have class or type info
-                has_type_info = (
-                    "class" in field_info
-                    or "is_struct" in field_info
-                    or "is_numeric" in field_info
+    async def test_non_scalar_struct_recovery(self, eeglab_loaded_engine):
+        """Non-scalar structs (chanlocs, event) should have metadata, not error strings."""
+        ws = await eeglab_loaded_engine.get_workspace()
+        eeg = ws.get("EEG", {})
+        if isinstance(eeg, dict):
+            # If chanlocs is present, it should not be a raw error string
+            chanlocs = eeg.get("chanlocs")
+            if chanlocs is not None and isinstance(chanlocs, str):
+                # Error strings typically start with "Error" or contain traceback
+                assert not chanlocs.startswith("Error"), (
+                    "chanlocs should have metadata, not error string"
                 )
-                if has_type_info:
-                    print(f"  {field_name}: {field_info.get('class', 'unknown')}")
-
-    @pytest.mark.asyncio
-    async def test_nested_struct_info(self):
-        """Test getting info for nested struct (EEG.chanlocs)."""
-        await self._load_eeg_data()
-
-        # Get info for chanlocs (struct array)
-        info = await self.engine.get_struct_info("EEG.chanlocs")
-
-        print(f"chanlocs info: {json.dumps(info, indent=2, default=str)}")
-
-    @pytest.mark.asyncio
-    async def test_nonexistent_variable(self):
-        """Test error handling for nonexistent variable."""
-        await self._load_eeg_data()
-
-        info = await self.engine.get_struct_info("nonexistent_var")
-
-        # Should return an error
-        assert "_mcp_error" in info
-        print(f"Error response: {info}")
-
-    def teardown_method(self, method):
-        """Clean up after each test."""
-        if hasattr(self, "engine") and self.engine.eng is not None:
-            self.engine.close()
-
-
-if __name__ == "__main__":
-    # Run a quick test
-    async def quick_test():
-        engine = MatlabEngine()
-        await engine.initialize()
-
-        # Create a simple struct for testing
-        result = await engine.execute(
-            "test_struct = struct('name', 'test', 'value', 42, 'data', rand(10,10));"
-        )
-        print(f"Created struct: {result.error or 'OK'}")
-
-        # Test get_struct_info
-        info = await engine.get_struct_info("test_struct")
-        print(f"Struct info: {json.dumps(info, indent=2, default=str)}")
-
-        # Test get_variable with fields
-        result = await engine.get_variable("test_struct", fields=["name", "value"])
-        print(f"Selected fields: {json.dumps(result, indent=2, default=str)}")
-
-        # Test list_workspace_variables
-        variables = await engine.list_workspace_variables()
-        print(f"Workspace: {json.dumps(variables, indent=2, default=str)}")
-
-        engine.close()
-
-    asyncio.run(quick_test())

--- a/tests/test_workspace_eeglab.py
+++ b/tests/test_workspace_eeglab.py
@@ -30,11 +30,18 @@ class TestGetVariable:
 
     @pytest.mark.asyncio
     async def test_depth_zero_returns_struct_info(self, eeglab_loaded_engine):
-        """depth=0 should return struct metadata, not actual values."""
+        """depth=0 should return per-field metadata, not raw data values."""
         result = await eeglab_loaded_engine.get_variable("EEG", depth=0)
         assert isinstance(result, dict)
-        # Should indicate it's a struct with type info
-        assert "_mcp_type" in result or "fields" in result or len(result) > 5
+        # Should have EEG field names as keys with metadata dicts as values
+        assert "nbchan" in result
+        assert "data" in result
+        # The data field should be metadata (dict with type info), not a raw array
+        data_entry = result["data"]
+        assert isinstance(data_entry, dict), (
+            f"depth=0 should return metadata for data, got {type(data_entry)}"
+        )
+        assert "bytes" in data_entry or "is_numeric" in data_entry
 
     @pytest.mark.asyncio
     async def test_nested_struct_chanlocs(self, eeglab_loaded_engine):
@@ -47,13 +54,20 @@ class TestGetVariable:
     async def test_data_max_elements_limits_transfer(self, eeglab_loaded_engine):
         """EEG.data with max_elements=50 should limit what is transferred."""
         result = await eeglab_loaded_engine.get_variable("EEG.data", max_elements=50)
-        # May return dict (summary) or truncated data (string/list)
         if isinstance(result, dict) and "_mcp_type" in result:
             assert result["_mcp_type"] in ["large_array", "medium_array"]
             if "sample" in result:
                 assert len(result["sample"]) <= 50
-        # If it returns raw data, it should be limited in size
-        # (not the full 32x30504 array)
+        elif isinstance(result, list):
+            # Raw list should be limited, not the full 32x30504 array
+            assert len(result) <= 50, (
+                f"max_elements=50 but got list of {len(result)} elements"
+            )
+        else:
+            # String representation or other format is acceptable
+            assert isinstance(result, (dict, str)), (
+                f"Unexpected result type: {type(result)}"
+            )
 
     @pytest.mark.asyncio
     async def test_nonexistent_variable(self, eeglab_loaded_engine):


### PR DESCRIPTION
## Summary
- Add 37 EEGLAB integration tests across 4 new/rewritten test files covering workspace retrieval, section execution, figure analysis, and full end-to-end pipeline
- Fix conftest.py EEGLAB path resolution (env var + updated default path)
- Update README with current 15-tool listing, Claude Code config, and updated features

## Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `test_workspace_eeglab.py` | 17 | get_variable, get_struct_info, list_workspace_variables, get_workspace |
| `test_sections_eeglab.py` | 9 | get_script_sections, execute by index/title/range, sequential execution |
| `test_figures_eeglab.py` | 7 | topoplot, ERP image, plot data, figure analysis, lint on EEGLAB code |
| `test_integration_eeglab.py` | 4 | full pipeline (load/filter/epoch/plot), scripted pipeline, error recovery |

## Key Changes
- **conftest.py**: EEGLAB_PATH env var support, shared `eeglab_loaded_engine` and `eeglab_epochs_engine` session fixtures, `fresh_continuous_eeg` function fixture for tests needing exact continuous data values
- **test_workspace_eeglab.py**: Rewritten to use shared engine (no more per-class engine creation), strong assertions with exact values (32ch, 128Hz, 30504 points)
- **README.md**: Updated features list, 15-tool table, Claude Code `.mcp.json` config example

## Test plan
- [x] All 37 EEGLAB tests pass with real MATLAB R2024b + EEGLAB
- [x] Full test suite (310+ tests) passes; 4 pre-existing lint test failures unrelated to this PR
- [x] ruff check and format clean
- [x] Tests skip gracefully when EEGLAB unavailable